### PR TITLE
modernize ai web designer stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,57 @@
 # AI Web Designer
-AI Web Designer is a web building tool powered by OpenAI's GPT API. It allows you to create and design static web pages with ease. The tool is programmed using ReactJS and is designed to help individuals and teams build web pages faster.
 
-You can now try it live at https://csansoon.github.io/ai-web-designer/!
+AI Web Designer is a React app for iteratively building static web pages with OpenAI. It combines a live preview, editable HTML/CSS/JS panes, and a chat workflow that can rewrite the page based on natural-language instructions.
 
-## Features
-- Real-time preview of HTML, CSS, and JS code
-- AI-powered auto-complete for faster coding
-- Token and price tracker
+Live demo: https://csansoon.github.io/ai-web-designer/
+
+## What's improved in this version
+
+- Upgraded the AI integration from the legacy OpenAI SDK flow to a modern structured-output chat integration.
+- Replaced the hardcoded `gpt-3.5-turbo` setup with selectable current models (`gpt-4.1-mini` and `gpt-4.1`).
+- Added stronger prompting and strict JSON schema responses so code updates are more reliable.
+- Improved error handling for invalid keys, rate limits, networking failures, and context-length issues.
+- Added a better starter template, model picker, API key management UX, and more useful session usage tracking.
+- Replaced the broken starter test with app- and utility-level coverage.
+
+## How it works
+
+The assistant receives the latest user request together with the current HTML, CSS, and JavaScript state of the page. It returns structured JSON containing:
+
+- `text`: the assistant reply shown in chat
+- `html`: optional replacement body markup
+- `css`: optional replacement stylesheet
+- `js`: optional replacement JavaScript
+
+Only the changed parts need to be returned, which keeps iteration fast and makes the app feel more like an AI design copilot than a single-shot generator.
+
+## Local development
+
+```bash
+npm install
+npm start
+```
+
+Then open `http://localhost:3000`.
+
+## Testing
+
+```bash
+npm test
+npm run build
+```
+
+## API key model
+
+This app currently sends requests directly from the browser to OpenAI using a user-provided API key stored in local storage. For safety:
+
+- prefer a project-scoped key
+- set a spend limit
+- do not use a high-privilege personal production key
+
+A future backend proxy could further improve security and observability, but this repo intentionally keeps the product as a static client app.
 
 ## Limitations
-Due to the limitations of OpenAI's API, AI Web Designer cannot handle large documents with too much content. The API has a maximum token limit of 4,000 per request, which means that the AI cannot generate large sections of code, or respond to the user when the document is too big.
 
-## How to Use
-To use AI Web Designer, follow the steps below:
-
-1. Clone the project from the GitHub repository.
-2. Run `npm install` to install the dependencies.
-3. Run `npm start` to start the development server.
-4. Access `http://localhost:3000` in your web browser.
-
-Once you have the tool up and running, you can start building your web page by asking the AI using the sidebar's chat. You can then customize the HTML, CSS, and JS code using the integrated code editor.
+- The app is optimized for a single static page rather than full multi-page apps.
+- Very large HTML/CSS/JS payloads can still hit model context limits.
+- Browser-side API usage is convenient for demos, but a server-side proxy is safer for production deployments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,20 +8,19 @@
       "name": "ai-web-designer",
       "version": "0.1.0",
       "dependencies": {
-        "@shoelace-style/shoelace": "^2.2.0",
+        "@shoelace-style/shoelace": "^2.20.1",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-        "@uiw/react-codemirror": "^4.19.9",
-        "openai": "^3.2.1",
+        "@uiw/react-codemirror": "^4.23.10",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-scripts": "5.0.1",
-        "react-textarea-autosize": "^8.4.0",
+        "react-textarea-autosize": "^8.5.9",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
-        "gh-pages": "^5.0.0"
+        "gh-pages": "^6.1.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2225,11 +2224,12 @@
       }
     },
     "node_modules/@ctrl/tinycolor": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.0.tgz",
-      "integrity": "sha512-/Z3l6pXthq0JvMYdUFyX9j0MaCltlIn6mfh9jLyQwg5aPKxkyNa0PTHtU1AlFXLNk55ZuAeJRcpvq+tmLfKmaQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
+      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -2304,17 +2304,29 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.2.tgz",
-      "integrity": "sha512-FaO9KVLFnxknZaGWGmNtjD2CVFuc0u4yeGEofoyXO2wgRA7fLtkngT6UB0vtWQWuhH3iMTZZ/Y89CMeyGfn8pA=="
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.2.3.tgz",
-      "integrity": "sha512-lK9cZUrHSJLMVAdCvDqs6Ug8gr0wmqksYiaoj/bxj2gweRQkSuhg2/V6Jswz2KiQ0RAULbqw1oQDJIMpQ5GfGA==",
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.2.2"
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
       }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
@@ -3118,22 +3130,28 @@
         "@lezer/common": "^1.0.0"
       }
     },
-    "node_modules/@lit-labs/react": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.1.1.tgz",
-      "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA=="
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.0.0.tgz",
-      "integrity": "sha512-ic93MBXfApIFTrup4a70M/+ddD8xdt2zxxj9sRwHQzhS9ag/syqkD8JPdTXsc1gUy2K8TTirhlCqyTEM/sifNw=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
+      "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@lit/react": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
+      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "@types/react": "17 || 18 || 19"
+      }
     },
     "node_modules/@lit/reactive-element": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.1.tgz",
-      "integrity": "sha512-va15kYZr7KZNNPZdxONGQzpUr+4sxVu7V/VG7a8mRfPPXUyhEYj5RzXCQmGrlP3tAh0L3HHm5AjBMFYRqlM9SA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
+      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -3325,31 +3343,34 @@
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
     },
     "node_modules/@shoelace-style/animations": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.1.0.tgz",
-      "integrity": "sha512-Be+cahtZyI2dPKRm8EZSx3YJQ+jLvEcn3xzRP7tM4tqBnvd/eW/64Xh0iOf0t2w5P8iJKfdBbpVNE9naCaOf2g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/animations/-/animations-1.2.0.tgz",
+      "integrity": "sha512-avvo1xxkLbv2dgtabdewBbqcJfV0e0zCwFqkPMnHFGbJbBHorRFfMAHh1NG9ymmXn0jW95ibUVH03E1NYXD6Gw==",
+      "license": "MIT",
       "funding": {
         "type": "individual",
         "url": "https://github.com/sponsors/claviska"
       }
     },
     "node_modules/@shoelace-style/localize": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.1.0.tgz",
-      "integrity": "sha512-evGxn5wIQh1/Ks1RbZm7rY4DxPKAUnXKTixZNgnYV/N2V8Bbbvsi+S14gNa42SQNUJK5WooNtlar2B8cehEwZQ=="
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/localize/-/localize-3.2.1.tgz",
+      "integrity": "sha512-r4C9C/5kSfMBIr0D9imvpRdCNXtUNgyYThc4YlS6K5Hchv1UyxNQ9mxwj+BTRH2i1Neits260sR3OjKMnplsFA==",
+      "license": "MIT"
     },
     "node_modules/@shoelace-style/shoelace": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.2.0.tgz",
-      "integrity": "sha512-53do7etYwygRRnx1tt5SPGfTL8YFtZVNTlfn5Tabno66otBXROKnUjWVqyLRP6xvj6BG6BP62DkZQG6pxIDMVg==",
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.20.1.tgz",
+      "integrity": "sha512-FSghU95jZPGbwr/mybVvk66qRZYpx5FkXL+vLNpy1Vp8UsdwSxXjIHE3fsvMbKWTKi9UFfewHTkc5e7jAqRYoQ==",
+      "license": "MIT",
       "dependencies": {
-        "@ctrl/tinycolor": "^3.5.0",
-        "@floating-ui/dom": "^1.2.1",
-        "@lit-labs/react": "^1.1.1",
-        "@shoelace-style/animations": "^1.1.0",
-        "@shoelace-style/localize": "^3.1.0",
-        "composed-offset-position": "^0.0.4",
-        "lit": "^2.6.1",
+        "@ctrl/tinycolor": "^4.1.0",
+        "@floating-ui/dom": "^1.6.12",
+        "@lit/react": "^1.0.6",
+        "@shoelace-style/animations": "^1.2.0",
+        "@shoelace-style/localize": "^3.2.1",
+        "composed-offset-position": "^0.0.6",
+        "lit": "^3.2.1",
         "qr-creator": "^1.0.0"
       },
       "engines": {
@@ -4672,9 +4693,10 @@
       }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
-      "version": "4.19.9",
-      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.19.9.tgz",
-      "integrity": "sha512-O4yAgVpD3Pon4t4+lwZ2MTGg2TeU/Jv8YzKS9ap4fP/WMTVrKmpdq+DOafbhZSlhmU0XGfQPPJ4WX6rtZgx3Rw==",
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/codemirror-extensions-basic-setup/-/codemirror-extensions-basic-setup-4.25.9.tgz",
+      "integrity": "sha512-QFAqr+pu6lDmNpAlecODcF49TlsrZ0bj15zPzfhiqSDl+Um3EsDLFLppixC7kFLn+rdDM2LTvVjn5CPvefpRgw==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -4683,6 +4705,9 @@
         "@codemirror/search": "^6.0.0",
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       },
       "peerDependencies": {
         "@codemirror/autocomplete": ">=6.0.0",
@@ -4695,16 +4720,20 @@
       }
     },
     "node_modules/@uiw/react-codemirror": {
-      "version": "4.19.9",
-      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.19.9.tgz",
-      "integrity": "sha512-U+A1fSfELMFFs5a+ZOPwCJKZMYaMy6QHOfNOOV7WhSveM7GYHT970GjTfs2dn1LlvhebwyK9ei0rCXZdsI9n9Q==",
+      "version": "4.25.9",
+      "resolved": "https://registry.npmjs.org/@uiw/react-codemirror/-/react-codemirror-4.25.9.tgz",
+      "integrity": "sha512-HftqCBUYShAOH0pGi1CHP8vfm5L8fQ3+0j0VI6lQD6QpK+UBu3J7nxfEN5O/BXMilMNf9ZyFJRvRcuMMOLHMng==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@codemirror/commands": "^6.1.0",
         "@codemirror/state": "^6.1.1",
         "@codemirror/theme-one-dark": "^6.0.0",
-        "@uiw/codemirror-extensions-basic-setup": "4.19.9",
+        "@uiw/codemirror-extensions-basic-setup": "4.25.9",
         "codemirror": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://jaywcjlove.github.io/#/sponsor"
       },
       "peerDependencies": {
         "@babel/runtime": ">=7.11.0",
@@ -4712,8 +4741,8 @@
         "@codemirror/theme-one-dark": ">=6.0.0",
         "@codemirror/view": ">=6.0.0",
         "codemirror": ">=6.0.0",
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
+        "react": ">=17.0.0",
+        "react-dom": ">=17.0.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -5148,15 +5177,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/array.prototype.flat": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
@@ -5298,14 +5318,6 @@
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/axobject-query": {
@@ -6099,9 +6111,13 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "node_modules/composed-offset-position": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
-      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.6.tgz",
+      "integrity": "sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@floating-ui/utils": "^0.2.5"
+      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -8770,18 +8786,19 @@
       }
     },
     "node_modules/gh-pages": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-5.0.0.tgz",
-      "integrity": "sha512-Nqp1SjkPIB94Xw/3yYNTUL+G2dxlhjvv1zeN/4kMC1jfViTEqhtVz/Ba1zSXHuvXCN9ADNS1dN4r5/J/nZWEQQ==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-6.3.0.tgz",
+      "integrity": "sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "async": "^3.2.4",
-        "commander": "^2.18.0",
+        "commander": "^13.0.0",
         "email-addresses": "^5.0.0",
         "filenamify": "^4.3.0",
         "find-cache-dir": "^3.3.1",
-        "fs-extra": "^8.1.0",
-        "globby": "^6.1.0"
+        "fs-extra": "^11.1.1",
+        "globby": "^11.1.0"
       },
       "bin": {
         "gh-pages": "bin/gh-pages.js",
@@ -8791,70 +8808,29 @@
         "node": ">=10"
       }
     },
-    "node_modules/gh-pages/node_modules/array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
-      "dev": true,
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/gh-pages/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/gh-pages/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/gh-pages/node_modules/globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
-      "dev": true,
-      "dependencies": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/gh-pages/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/gh-pages/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/glob": {
@@ -12139,28 +12115,32 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lit": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.6.1.tgz",
-      "integrity": "sha512-DT87LD64f8acR7uVp7kZfhLRrHkfC/N4BVzAtnw9Yg8087mbBJ//qedwdwX0kzDbxgPccWRW6mFwGbRQIxy0pw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
+      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.2.0",
-        "lit-html": "^2.6.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.2.2.tgz",
-      "integrity": "sha512-6ZgxBR9KNroqKb6+htkyBwD90XGRiqKDHVrW/Eh0EZ+l+iC+u+v+w3/BA5NGi4nizAVHGYvQBHUDuSmLjPp7NQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
+      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.2.0"
+        "@lit-labs/ssr-dom-shim": "^1.5.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.6.1.tgz",
-      "integrity": "sha512-Z3iw+E+3KKFn9t2YKNjsXNEu/LRLI98mtH/C6lnFg7kvaqPIzPn124Yd4eT/43lyqrejpc5Wb6BHq3fdv4S8Rw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
+      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -12845,28 +12825,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/openai": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-3.2.1.tgz",
-      "integrity": "sha512-762C9BNlJPbjjlWZi4WYK9iM2tAVAv0uUp1UmI34vb0CN5T2mjB/qM6RYBmNKMh/dN9fC+bxqPwWJZUTWW052A==",
-      "dependencies": {
-        "axios": "^0.26.0",
-        "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/openai/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -13057,27 +13015,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
-      "dev": true,
-      "dependencies": {
-        "pinkie": "^2.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14875,11 +14812,12 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
-      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.5.9.tgz",
+      "integrity": "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.20.13",
         "use-composed-ref": "^1.3.0",
         "use-latest": "^1.2.1"
       },
@@ -14887,7 +14825,7 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -4,16 +4,15 @@
   "homepage": "https://csansoon.github.io/ai-web-designer",
   "private": true,
   "dependencies": {
-    "@shoelace-style/shoelace": "^2.2.0",
+    "@shoelace-style/shoelace": "^2.20.1",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-    "@uiw/react-codemirror": "^4.19.9",
-    "openai": "^3.2.1",
+    "@uiw/react-codemirror": "^4.23.10",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",
-    "react-textarea-autosize": "^8.4.0",
+    "react-textarea-autosize": "^8.5.9",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -21,7 +20,7 @@
     "deploy": "gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
@@ -43,6 +42,6 @@
     ]
   },
   "devDependencies": {
-    "gh-pages": "^5.0.0"
+    "gh-pages": "^6.1.1"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,159 +1,280 @@
 import './styles/colors.css';
 import './styles/App.css';
-import { useState } from 'react';
-import { SlButton, SlDialog, SlInput } from "@shoelace-style/shoelace/dist/react";
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { SlButton, SlDialog, SlInput, SlSelect, SlOption } from '@shoelace-style/shoelace/dist/react';
 
-import {TabList, Tab} from './components/Tabs';
+import { TabList, Tab } from './components/Tabs';
 import VirtualPage from './components/VirtualPage';
 import Editor from './components/Editor';
 import Chat from './components/Chat';
 
 import ChatMessage from './components/ChatMessage';
-import AI from './model/AI';
+import AI, { MODELS, STORAGE_KEYS } from './model/AI';
 
-function App() {
+const DEFAULT_HTML = `<main class="hero">
+  <section>
+    <p class="eyebrow">AI web designer</p>
+    <h1>Describe a landing page and iterate with AI.</h1>
+    <p class="subtitle">Ask for layout, styling, copy, or interactions, then refine the generated page in the editors.</p>
+    <button type="button">Start designing</button>
+  </section>
+</main>`;
 
-	const [html, setHtml] = useState("<h1>Hello world!</h1>");
-	const [css, setCss] = useState("");
-	const [js, setJs] = useState("");
-	const [messages, setMessages] = useState([]);
-
-	const [loadingResponse, setLoadingResponse] = useState(false);
-
-	const [usedTokens, setUsedTokens] = useState("0");
-	const [moneySpent, setMoneySpent] = useState("0.00");
-
-	// Show a Dialog if the API key is not set in the localStorage yet or if it is not valid
-	const [isCheckingAPIKey, setIsCheckingAPIKey] = useState(false);
-	const [showAPIKeyDialog, setShowAPIKeyDialog] = useState(!AI.isInitialized && !localStorage.getItem("api_key"));
-
-	if (localStorage.getItem("api_key") && !AI.isInitialized && !isCheckingAPIKey) {
-		checkAPIKeyValidity();
-	}
-
-	function checkAPIKeyValidity() {
-		setIsCheckingAPIKey(true);
-		AI.checkAPIKey(localStorage.getItem("api_key")).then((isValid) => {
-			if (isValid) {
-				AI.initWithKey(localStorage.getItem("api_key"));
-				setShowAPIKeyDialog(false);
-			} else {
-				localStorage.removeItem("api_key");
-				setShowAPIKeyDialog(true);
-			}
-			setIsCheckingAPIKey(false);
-		});
-	}
-
-	function addMessage(message_text) {
-		if (loadingResponse) {
-			console.error("Can't send message while waiting for response");
-			return;
-		}
-		setLoadingResponse(true);
-
-		const newMessages = [
-			...messages,
-			new ChatMessage("user", message_text, html, css, js)
-		]
-		setMessages(newMessages);
-
-		AI.getResponseMessage(newMessages).then(responseMessage => {
-			setMessages([...newMessages, responseMessage]);
-			setLoadingResponse(false);
-
-			let _used_tokens = AI.totalUsedTokens;
-			let _money_spent = AI.totalUsedTokensUSD.toFixed(4);
-			if (AI.totalUsedTokens > 1000) _used_tokens = Math.round(AI.totalUsedTokens / 1000) + "k";
-			if (AI.totalUsedTokens > 1000000) _used_tokens = Math.round(AI.totalUsedTokens / 1000000) + "M";
-			setUsedTokens(_used_tokens);
-			setMoneySpent(_money_spent);
-			
-
-			if (responseMessage.html) setHtml(responseMessage.html);
-			if (responseMessage.css) setCss(responseMessage.css);
-			if (responseMessage.js) setJs(responseMessage.js);
-		});
-	}
-
-	function downloadHtmlFile() {
-
-		const html_file = `
-			<html>
-				<head>
-					<style>${css}</style>
-				</head>
-				<body>
-					${html}
-					<script>${js}</script>
-				</body>
-			</html>
-		`;
-
-		const element = document.createElement("a");
-		const file = new Blob([html_file], { type: 'text/html' });
-		element.href = URL.createObjectURL(file);
-		element.download = "index.html";
-		document.body.appendChild(element); // Required for this to work in FireFox
-		element.click();
-		document.body.removeChild(element);
-	}
-
-	return (
-		<div className="App">
-			
-			<APIKeyDialog show={showAPIKeyDialog} loading={isCheckingAPIKey} checkAPIKeyValidity={checkAPIKeyValidity} />
-			<div className="container">
-				<div>
-					<TabList html={html} css={css} js={js} loadingResponse={loadingResponse} downloadFunction={ downloadHtmlFile }>
-						<Tab key="page" label="Preview" icon="card-image" >
-							<VirtualPage html={html} css={css} js={js} />
-						</Tab>
-						<Tab key="html" label="Elements" icon="code-slash">
-							<Editor language="html" displayName="HTML" value={html} onChange={setHtml} />
-						</Tab>
-						<Tab key="css" label="Styles" icon="palette">
-							<Editor language="css" displayName="CSS" value={css} onChange={setCss} />
-						</Tab>
-						<Tab key="js" label="Code" icon="braces">
-							<Editor language="javascript" displayName="JS" value={js} onChange={setJs} />
-						</Tab>
-					</TabList>
-				</div>
-				<div style={{width: "600px"}}>
-					<Chat messages={messages} addMessage={addMessage} loadingResponse={loadingResponse} usedTokens={usedTokens} moneySpent={moneySpent} />
-				</div>
-			</div>
-		</div>
-	);
+const DEFAULT_CSS = `.hero {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 48px 24px;
+  font-family: Inter, system-ui, sans-serif;
+  background: radial-gradient(circle at top, #1d4ed8, #0f172a 60%);
+  color: white;
 }
 
+.hero section {
+  max-width: 720px;
+}
 
-function APIKeyDialog({show, loading, checkAPIKeyValidity}) {
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #93c5fd;
+  font-size: 0.75rem;
+}
 
-	function handleRequestClose(event) {
-		console.log("Dialog closed");
-		if (!AI.isInitialized) {
-			event.preventDefault();
-		}
-	}
+.subtitle {
+  color: rgba(255, 255, 255, 0.82);
+  line-height: 1.6;
+}
 
-	function saveAPIKey() {
-		const input = document.querySelector("sl-input");
-		const new_key = input.value;
-		localStorage.setItem("api_key", new_key);
-		checkAPIKeyValidity();
-	}
+button {
+  margin-top: 24px;
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 20px;
+  font-weight: 600;
+  background: white;
+  color: #0f172a;
+  cursor: pointer;
+}`;
 
-	return (
-		<SlDialog open={show} label="Provide your OpenAI's API key" onSlRequestClose={handleRequestClose}>
-			Provide your own OpenAI's API key to use the chatbot. <a href="https://help.openai.com/en/articles/4936850-where-do-i-find-my-secret-api-key" target="_blank" rel="noreferrer">Where do I find my secret API key?</a>
-			<div style={{marginTop: "24px"}} />
-			<SlInput type="text" placeholder="sk-..." disabled={loading} />
-			<SlButton slot="footer" onClick={saveAPIKey} loading={loading}>Save</SlButton>
-		</SlDialog>
-	);
+function App() {
+  const [html, setHtml] = useState(DEFAULT_HTML);
+  const [css, setCss] = useState(DEFAULT_CSS);
+  const [js, setJs] = useState('');
+  const [messages, setMessages] = useState([]);
+  const [draft, setDraft] = useState('');
+  const [loadingResponse, setLoadingResponse] = useState(false);
+  const [usedTokens, setUsedTokens] = useState('0');
+  const [moneySpent, setMoneySpent] = useState('0.0000');
+  const [selectedModel, setSelectedModel] = useState(AI.getSelectedModel());
 
+  const [isCheckingAPIKey, setIsCheckingAPIKey] = useState(false);
+  const [showAPIKeyDialog, setShowAPIKeyDialog] = useState(!AI.isInitialized && !localStorage.getItem(STORAGE_KEYS.apiKey));
+
+  const modelDescription = useMemo(() => MODELS[selectedModel]?.description || '', [selectedModel]);
+
+  const checkAPIKeyValidity = useCallback(async (keyFromArgument) => {
+    const key = keyFromArgument || localStorage.getItem(STORAGE_KEYS.apiKey);
+
+    if (!key || isCheckingAPIKey) {
+      return;
+    }
+
+    setIsCheckingAPIKey(true);
+
+    const isValid = await AI.checkAPIKey(key);
+
+    if (isValid) {
+      AI.initWithKey(key);
+      setShowAPIKeyDialog(false);
+    } else {
+      AI.clear();
+      localStorage.removeItem(STORAGE_KEYS.apiKey);
+      setShowAPIKeyDialog(true);
+    }
+
+    setIsCheckingAPIKey(false);
+  }, [isCheckingAPIKey]);
+
+  useEffect(() => {
+    const storedKey = localStorage.getItem(STORAGE_KEYS.apiKey);
+
+    if (storedKey && !AI.isInitialized) {
+      checkAPIKeyValidity(storedKey);
+    }
+  }, [checkAPIKeyValidity]);
+
+  async function addMessage(messageText) {
+    const trimmedMessage = messageText.trim();
+
+    if (!trimmedMessage || loadingResponse) {
+      return;
+    }
+
+    setLoadingResponse(true);
+
+    const newMessages = [
+      ...messages,
+      new ChatMessage('user', trimmedMessage, html, css, js),
+    ];
+
+    setMessages(newMessages);
+    setDraft('');
+
+    const responseMessage = await AI.getResponseMessage(newMessages);
+    const updatedMessages = [...newMessages, responseMessage];
+
+    setMessages(updatedMessages);
+    setLoadingResponse(false);
+
+    let formattedTokens = AI.totalUsedTokens.toString();
+    if (AI.totalUsedTokens >= 1000) formattedTokens = `${Math.round(AI.totalUsedTokens / 1000)}k`;
+    if (AI.totalUsedTokens >= 1000000) formattedTokens = `${Math.round(AI.totalUsedTokens / 1000000)}M`;
+
+    setUsedTokens(formattedTokens);
+    setMoneySpent(AI.totalUsedTokensUSD.toFixed(4));
+
+    if (responseMessage.html !== undefined) setHtml(responseMessage.html);
+    if (responseMessage.css !== undefined) setCss(responseMessage.css);
+    if (responseMessage.js !== undefined) setJs(responseMessage.js);
+  }
+
+  function downloadHtmlFile() {
+    const htmlFile = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ai-web-designer export</title>
+    <style>${css}</style>
+  </head>
+  <body>
+    ${html}
+    <script>${js}</script>
+  </body>
+</html>`;
+
+    const element = document.createElement('a');
+    const file = new Blob([htmlFile], { type: 'text/html' });
+    element.href = URL.createObjectURL(file);
+    element.download = 'index.html';
+    document.body.appendChild(element);
+    element.click();
+    document.body.removeChild(element);
+    URL.revokeObjectURL(element.href);
+  }
+
+  function resetExample() {
+    setHtml(DEFAULT_HTML);
+    setCss(DEFAULT_CSS);
+    setJs('');
+    setMessages([
+      new ChatMessage('assistant', 'I reset the page to the starter template. Ask for a redesign, sections, animations, or specific copy.'),
+    ]);
+  }
+
+  function handleModelChange(event) {
+    const newModel = event.target.value;
+    AI.setSelectedModel(newModel);
+    setSelectedModel(newModel);
+    setMoneySpent(AI.totalUsedTokensUSD.toFixed(4));
+  }
+
+  return (
+    <div className="App">
+      <APIKeyDialog show={showAPIKeyDialog} loading={isCheckingAPIKey} checkAPIKeyValidity={checkAPIKeyValidity} />
+
+      <div className="container">
+        <div>
+          <TabList html={html} css={css} js={js} loadingResponse={loadingResponse} downloadFunction={downloadHtmlFile}>
+            <Tab key="page" label="Preview" icon="card-image">
+              <VirtualPage html={html} css={css} js={js} />
+            </Tab>
+            <Tab key="html" label="Elements" icon="code-slash">
+              <Editor language="html" displayName="HTML" value={html} onChange={setHtml} />
+            </Tab>
+            <Tab key="css" label="Styles" icon="palette">
+              <Editor language="css" displayName="CSS" value={css} onChange={setCss} />
+            </Tab>
+            <Tab key="js" label="Code" icon="braces">
+              <Editor language="javascript" displayName="JS" value={js} onChange={setJs} />
+            </Tab>
+          </TabList>
+        </div>
+
+        <div className="sidebar-panel">
+          <div className="settings-panel">
+            <SlSelect value={selectedModel} label="Model" onSlChange={handleModelChange} hoist>
+              {Object.entries(MODELS).map(([value, model]) => (
+                <SlOption key={value} value={value}>{model.label}</SlOption>
+              ))}
+            </SlSelect>
+            <p className="settings-help">{modelDescription}</p>
+            <div className="settings-actions">
+              <SlButton size="small" onClick={resetExample}>Reset starter</SlButton>
+              <SlButton size="small" variant="default" onClick={() => setShowAPIKeyDialog(true)}>API key</SlButton>
+            </div>
+          </div>
+          <Chat
+            messages={messages}
+            draft={draft}
+            setDraft={setDraft}
+            addMessage={addMessage}
+            loadingResponse={loadingResponse}
+            usedTokens={usedTokens}
+            moneySpent={moneySpent}
+            selectedModel={selectedModel}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function APIKeyDialog({ show, loading, checkAPIKeyValidity }) {
+  const [value, setValue] = useState(localStorage.getItem(STORAGE_KEYS.apiKey) || '');
+
+  useEffect(() => {
+    setValue(localStorage.getItem(STORAGE_KEYS.apiKey) || '');
+  }, [show]);
+
+  function handleRequestClose(event) {
+    if (!AI.isInitialized) {
+      event.preventDefault();
+    }
+  }
+
+  function saveAPIKey() {
+    const nextValue = value.trim();
+    localStorage.setItem(STORAGE_KEYS.apiKey, nextValue);
+    checkAPIKeyValidity(nextValue);
+  }
+
+  function onKeyDown(event) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      saveAPIKey();
+    }
+  }
+
+  return (
+    <SlDialog open={show} label="Provide your OpenAI API key" onSlRequestClose={handleRequestClose}>
+      This app sends requests directly from your browser to OpenAI using your key. Use a project-scoped key with an appropriate spend limit.
+      <div style={{ marginTop: '24px' }} />
+      <SlInput
+        type="password"
+        placeholder="sk-..."
+        value={value}
+        disabled={loading}
+        onSlInput={(event) => setValue(event.target.value)}
+        onKeyDown={onKeyDown}
+      />
+      <div style={{ marginTop: '12px', color: 'var(--sl-color-neutral-500)' }}>
+        <a href="https://platform.openai.com/api-keys" target="_blank" rel="noreferrer">OpenAI API keys</a>
+      </div>
+      <SlButton slot="footer" onClick={saveAPIKey} loading={loading} disabled={!value.trim()}>Save</SlButton>
+    </SlDialog>
+  );
 }
 
 export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,43 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
+import { extractJsonObject, sanitizeResponsePayload } from './model/AI';
+import { buildPreviewDocument } from './components/VirtualPage';
 
-test('renders learn react link', () => {
+beforeEach(() => {
+  localStorage.clear();
+  jest.spyOn(global, 'fetch').mockResolvedValue({ ok: false });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('renders model selector and starter guidance', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+
+  expect(screen.getByText(/describe the page you want to build/i)).toBeInTheDocument();
+  expect(screen.getAllByText(/gpt-4.1-mini/i).length).toBeGreaterThan(0);
+  expect(screen.getByText(/reset starter/i)).toBeInTheDocument();
+});
+
+test('extractJsonObject trims wrapper text', () => {
+  expect(extractJsonObject('note {"text":"hello"} thanks')).toEqual({ text: 'hello' });
+});
+
+test('sanitizeResponsePayload ensures text exists', () => {
+  expect(sanitizeResponsePayload({ html: '<h1>Hi</h1>' })).toEqual({
+    text: 'Done.',
+    html: '<h1>Hi</h1>',
+    css: undefined,
+    js: undefined,
+  });
+});
+
+test('buildPreviewDocument creates complete HTML document', () => {
+  const doc = buildPreviewDocument('<h1>Hello</h1>', 'body{color:red;}', 'console.log("hi")');
+
+  expect(doc).toContain('<!doctype html>');
+  expect(doc).toContain('<h1>Hello</h1>');
+  expect(doc).toContain('body{color:red;}');
+  expect(doc).toContain('console.log("hi")');
 });

--- a/src/components/Chat.js
+++ b/src/components/Chat.js
@@ -1,63 +1,75 @@
-import '../styles/Chat.css'
-import { SlTooltip, SlButton, SlIcon, SlBadge } from "@shoelace-style/shoelace/dist/react";
-import TextareaAutosize from "react-textarea-autosize";
+import '../styles/Chat.css';
+import { SlTooltip, SlButton, SlIcon, SlBadge } from '@shoelace-style/shoelace/dist/react';
+import TextareaAutosize from 'react-textarea-autosize';
 
-export default function Chat({ messages, addMessage, loadingResponse, usedTokens, moneySpent}) {
+export default function Chat({
+  messages,
+  draft,
+  setDraft,
+  addMessage,
+  loadingResponse,
+  usedTokens,
+  moneySpent,
+  selectedModel,
+}) {
+  const sendMessage = () => {
+    addMessage(draft);
+  };
 
-	const sendMessage = () => {
-		const input = document.querySelector(".chat-input textarea");
-		addMessage(input.value);
-		input.value = "";
-	}
+  const onKeyDown = (event) => {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      sendMessage();
+    }
+  };
 
-	const onClick = (event) => {
-		// if shift + enter, add a new line
+  return (
+    <div className="chat-container">
+      <div className="chat-container-inner">
+        <div className="chat-header">
+          <SlTooltip content="Currently selected model.">
+            <SlBadge>{selectedModel}</SlBadge>
+          </SlTooltip>
+          <SlTooltip content="Total tokens used in this session.">
+            <SlBadge>{usedTokens} tokens</SlBadge>
+          </SlTooltip>
+          <SlTooltip content="Estimated spend based on the selected model's published pricing.">
+            <SlBadge>$ {moneySpent}</SlBadge>
+          </SlTooltip>
+        </div>
 
-		if (event.key === "Enter" && !event.shiftKey) {
-			event.preventDefault();
-			sendMessage();
-		}
-	}
+        <div className="chat-messages">
+          {messages.length === 0 ? (
+            <div className="chat-empty-state">
+              Describe the page you want to build. For example: “Create a SaaS landing page with a hero, pricing cards, FAQ, and smooth scroll animations.”
+            </div>
+          ) : (
+            messages.map((message, key) => message.render(key))
+          )}
+        </div>
 
-	return (
-		<div className="chat-container">
-			<div className="chat-container-inner">
-				<div className="chat-header">
-					<SlTooltip content="Each token represents a word, a group of characters or a concept that the AI can understand.">
-						<SlBadge>
-							{usedTokens} tokens
-						</SlBadge>
-					</SlTooltip>
-					<SlTooltip content="1k tokens cost $0.002 USD.">
-						<SlBadge>
-							$ {moneySpent}
-						</SlBadge>
-					</SlTooltip>
-				</div>
-
-				<div className="chat-messages">
-					{messages.map((message, key) => {
-						return <>{message.render(key)}</>;
-					})}
-				</div>
-				<div className="chat-input">
-					<TextareaAutosize
-						onKeyPress={onClick}
-						disabled={loadingResponse}
-					/>
-					<SlTooltip content="Send">
-						<SlButton
-							onClick={sendMessage}
-							aria-label="Send"
-							variant="primary"
-							loading={loadingResponse}
-							circle
-						>
-							<SlIcon name="send" />
-						</SlButton>
-					</SlTooltip>
-				</div>
-			</div>
-		</div>
-	);
+        <div className="chat-input">
+          <TextareaAutosize
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={onKeyDown}
+            placeholder="Ask the AI to design or refine your page..."
+            disabled={loadingResponse}
+            minRows={2}
+          />
+          <SlTooltip content="Send">
+            <SlButton
+              onClick={sendMessage}
+              aria-label="Send"
+              variant="primary"
+              loading={loadingResponse}
+              circle
+            >
+              <SlIcon name="send" />
+            </SlButton>
+          </SlTooltip>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/src/components/ChatMessage.js
+++ b/src/components/ChatMessage.js
@@ -1,25 +1,20 @@
-// import React from 'react';
-
 class ChatMessage {
+  constructor(role, message, html, css, js) {
+    this.role = role;
+    this.message = message;
+    this.html = html;
+    this.css = css;
+    this.js = js;
+  }
 
-	constructor(role, message, html, css, js) {
-		this.role = role;
-		this.message = message;
-		this.html = html;
-		this.css = css;
-		this.js = js;
-	}
-
-
-	render(key) {
-		return (
-			<div className={`chat-message ${this.role}`} key={key}>
-				<div className="chat-message-content">
-					{this.message}
-				</div>
-			</div>
-		);
-	}
+  render(key) {
+    return (
+      <div className={`chat-message ${this.role}`} key={key}>
+        <div className="chat-message-role">{this.role === 'assistant' ? 'AI' : this.role === 'user' ? 'You' : 'System'}</div>
+        <div className="chat-message-content">{this.message}</div>
+      </div>
+    );
+  }
 }
 
 export default ChatMessage;

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -1,22 +1,12 @@
-import { useEffect, useRef } from 'react';
-import "../styles/Editor.css";
+import '../styles/Editor.css';
 
 import React from 'react';
 import CodeMirror from '@uiw/react-codemirror';
-// import { javascript } from '@codemirror/lang-javascript';
-// import { css } from '@codemirror/lang-css';
-// import { html } from '@codemirror/lang-html';
 
-export default function Editor({ language, displayName, value, onChange }) {
-
-    function handleChange(value) {
-        onChange(value);
-    }
-
-    return (
-        <div className="editor-container">
-            <CodeMirror value={value} onChange={handleChange} options={{ mode: language, theme: "material", lineNumbers: true }} />
-        </div>
-    )
-
+export default function Editor({ value, onChange }) {
+  return (
+    <div className="editor-container">
+      <CodeMirror value={value} onChange={onChange} theme="dark" />
+    </div>
+  );
 }

--- a/src/components/VirtualPage.js
+++ b/src/components/VirtualPage.js
@@ -1,40 +1,31 @@
+function buildPreviewDocument(html, css, js) {
+  const safeHtml = typeof html === 'string' && html.trim() ? html : '<main><h1>Your page preview will appear here.</h1></main>';
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>${css || ''}</style>
+  </head>
+  <body>
+    ${safeHtml}
+    <script>${js || ''}</script>
+  </body>
+</html>`;
+}
+
+export { buildPreviewDocument };
 
 export default function VirtualPage({ html, css, js }) {
-	/*
-		Render an iframe with the given HTML, CSS and JS.
-	*/
-
-	const isHtmlValid = (html) => {
-		/*
-			Validate the given HTML.
-		*/
-
-		const parser = new DOMParser();
-		const doc = parser.parseFromString(html, "text/html");
-
-		return doc.body.innerHTML !== "";
-	}
-	
-	const htmlWithCSSAndJS = `
-		<html>
-			<head>
-				<style>${css}</style>
-			</head>
-			<body>
-				${isHtmlValid(html) ? html : "<h1>Invalid HTML</h1>"}
-				<script>${js}</script>
-			</body>
-		</html>
-	`;
-
-	return (
-		<iframe
-			srcDoc={htmlWithCSSAndJS}
-			title="Virtual Page"
-			sandbox="allow-scripts"
-			frameBorder="0"
-			width="100%"
-			height="100%"
-		/>
-	);
+  return (
+    <iframe
+      srcDoc={buildPreviewDocument(html, css, js)}
+      title="Virtual Page"
+      sandbox="allow-scripts"
+      frameBorder="0"
+      width="100%"
+      height="100%"
+    />
+  );
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,18 +4,15 @@ import './styles/index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 
-import "@shoelace-style/shoelace/dist/themes/light.css";
-import { setBasePath } from "@shoelace-style/shoelace/dist/utilities/base-path";
-setBasePath("https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.0.0/dist/");
+import '@shoelace-style/shoelace/dist/themes/light.css';
+import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path';
+setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.1/cdn/');
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-	<App />
-  </React.StrictMode>
+    <App />
+  </React.StrictMode>,
 );
 
-// If you want to start measuring performance in your app, pass a function
-// to log results (for example: reportWebVitals(console.log))
-// or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();

--- a/src/model/AI.js
+++ b/src/model/AI.js
@@ -1,199 +1,265 @@
 import ChatMessage from '../components/ChatMessage';
 
-import { Configuration, OpenAIApi } from 'openai';
+const STORAGE_KEYS = {
+    apiKey: 'api_key',
+    selectedModel: 'selected_model',
+};
+
+const MODELS = {
+    'gpt-4.1-mini': {
+        label: 'gpt-4.1-mini',
+        inputCostPerMillion: 0.4,
+        outputCostPerMillion: 1.6,
+        description: 'Fast default for iterative web design edits.',
+    },
+    'gpt-4.1': {
+        label: 'gpt-4.1',
+        inputCostPerMillion: 2,
+        outputCostPerMillion: 8,
+        description: 'Higher quality for larger or trickier page rewrites.',
+    },
+};
+
+const RESPONSE_SCHEMA = {
+    name: 'web_designer_response',
+    schema: {
+        type: 'object',
+        additionalProperties: false,
+        properties: {
+            text: {
+                type: 'string',
+                description: 'A concise explanation of what changed or what is needed from the user.',
+            },
+            html: {
+                type: 'string',
+                description: 'Replacement HTML for the body content only.',
+            },
+            css: {
+                type: 'string',
+                description: 'Replacement CSS for the page.',
+            },
+            js: {
+                type: 'string',
+                description: 'Replacement JavaScript for the page.',
+            },
+        },
+        required: ['text'],
+    },
+    strict: true,
+};
+
+function extractJsonObject(text) {
+    if (!text || typeof text !== 'string') {
+        throw new Error('Missing response text');
+    }
+
+    const start = text.indexOf('{');
+    const end = text.lastIndexOf('}');
+
+    if (start === -1 || end === -1 || end < start) {
+        throw new Error('Response did not contain JSON');
+    }
+
+    return JSON.parse(text.slice(start, end + 1));
+}
+
+function sanitizeResponsePayload(payload) {
+    const parsed = payload || {};
+
+    return {
+        text: typeof parsed.text === 'string' && parsed.text.trim() ? parsed.text.trim() : 'Done.',
+        html: typeof parsed.html === 'string' ? parsed.html : undefined,
+        css: typeof parsed.css === 'string' ? parsed.css : undefined,
+        js: typeof parsed.js === 'string' ? parsed.js : undefined,
+    };
+}
+
+function buildSystemPrompt() {
+    return [
+        'You are an expert AI web designer embedded inside a browser-based HTML/CSS/JS editor.',
+        'Your job is to help users iteratively design a single static web page.',
+        'You will receive JSON from the user with these fields when available: text, html, css, js.',
+        'The html field always represents the contents of the <body> tag only. Never add <html>, <head>, or <body> wrappers.',
+        'Return valid JSON that matches the required schema.',
+        'Always include the text field.',
+        'Only include html, css, or js when you want to replace that part of the current page.',
+        'Keep code readable and production-like. Prefer semantic HTML, modern CSS, and unobtrusive JavaScript.',
+        'If the user asks for something unsafe or impossible in a static page, explain that in text and provide the closest safe alternative.',
+        'When updating code, preserve existing good work unless the user asked for a redesign.',
+    ].join('\n');
+}
+
+function buildMessages(messages) {
+    return messages
+        .filter((message) => message.role !== 'system')
+        .map((message, index) => {
+            let payload = {};
+
+            if (message.role === 'user') {
+                if (index === messages.length - 1) {
+                    payload = {
+                        text: message.message,
+                        html: message.html || '',
+                        css: message.css || '',
+                        js: message.js || '',
+                    };
+                } else {
+                    payload = {
+                        text: message.message,
+                    };
+                }
+            } else {
+                payload = sanitizeResponsePayload({
+                    text: message.message,
+                    html: message.html,
+                    css: message.css,
+                    js: message.js,
+                });
+            }
+
+            return {
+                role: message.role,
+                content: JSON.stringify(payload),
+            };
+        });
+}
 
 class AI {
-    static _config = null;
-    static _OpenAIClient = null;
-    static _totalUsedTokens = 0;
+    static _apiKey = null;
+    static _totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
 
     static initWithKey(key) {
-        AI._config = new Configuration({
-            apiKey: key,
-        });
-        AI._OpenAIClient = new OpenAIApi(AI._config);
-        AI._totalUsedTokens = 0;
+        AI._apiKey = key;
+        AI._totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    }
+
+    static clear() {
+        AI._apiKey = null;
+        AI._totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
     }
 
     static get isInitialized() {
-        return AI._config && AI._OpenAIClient;
+        return Boolean(AI._apiKey);
+    }
+
+    static get availableModels() {
+        return MODELS;
+    }
+
+    static getSelectedModel() {
+        return localStorage.getItem(STORAGE_KEYS.selectedModel) || 'gpt-4.1-mini';
+    }
+
+    static setSelectedModel(model) {
+        if (!MODELS[model]) {
+            throw new Error(`Unsupported model: ${model}`);
+        }
+
+        localStorage.setItem(STORAGE_KEYS.selectedModel, model);
     }
 
     static async checkAPIKey(key) {
-        const config = new Configuration({
-            apiKey: key,
-        });
         try {
-            const OpenAIClient = new OpenAIApi(config);
-            await OpenAIClient.listModels();
-            return true;
-        }
-        catch (e) {
+            const response = await fetch('https://api.openai.com/v1/models', {
+                headers: {
+                    Authorization: `Bearer ${key}`,
+                },
+            });
+
+            return response.ok;
+        } catch (error) {
+            console.error(error);
             return false;
         }
     }
 
     static get totalUsedTokens() {
-        return AI._totalUsedTokens;
+        return AI._totalUsage.totalTokens;
     }
 
     static get totalUsedTokensUSD() {
-        return (AI._totalUsedTokens * 0.002) / 1000;
+        const pricing = MODELS[AI.getSelectedModel()] || MODELS['gpt-4.1-mini'];
+        const inputCost = (AI._totalUsage.inputTokens / 1_000_000) * pricing.inputCostPerMillion;
+        const outputCost = (AI._totalUsage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
+        return inputCost + outputCost;
     }
 
     static async getResponseMessage(messages) {
-        if (!AI._config || !AI._OpenAIClient) {
-            console.error("AI not initialized");
-            return new ChatMessage("system", "The API key is not valid.");
+        if (!AI.isInitialized) {
+            return new ChatMessage('system', 'Add a valid OpenAI API key to start generating pages.');
         }
 
-        const guidelines = [
-            "You are a bot that can generate HTML, CSS and JS code.",
-            "You will recieve messages from the user containing a JSON object. This object will contain the following fields:",
-            "- text: The text message from the user",
-            "- html: The HTML code of the user's webpage inside the <body> tag",
-            "- css: The full CSS code of the user's webpage",
-            "- js: The full JavaScript code of the user's webpage",
-            "You will reply to the user with another JSON object **and nothing more**.",
-            "You will add the 'html', 'css' and 'js' fields only if you changed them. When adding any code field, format it in a readable way.",
-            "You can only edit the <body> tag of the HTML code, so everything else should be left as it is.",
-            "Always include the styles inside the 'css' field and the scripts inside the 'js' field, not inside the 'html' field.",
-            "Your response will **always** contain the 'text' field, which will be the response you send to the user.",
-            "Your response will **never** contain just a text message, it will always contain a JSON object and nothing more.",
-            "**Do not** add any notes or additional text to your response other than the JSON itself, not even before or after the JSON.",
-        ];
-
-        const prompt_and_examples = [
-            {
-                role: "system",
-                content: guidelines.join("\n")
+        const model = AI.getSelectedModel();
+        const requestBody = {
+            model,
+            temperature: 0.3,
+            response_format: {
+                type: 'json_schema',
+                json_schema: RESPONSE_SCHEMA,
             },
-            {
-                role: "user",
-                content: JSON.stringify({
-                    text: "Hello!"
-                })
-            },
-            {
-                role: "assistant",
-                content: JSON.stringify({
-                    text: "Hi, how can I help you?"
-                })
-            },
-            {
-                role: "user",
-                content: JSON.stringify({
-                    text: "Please add a title that says \"Hello world!\"",
-                })
-            },
-            {
-                role: "assistant",
-                content: JSON.stringify({
-                    html: "<h1>\n\tHello world!\n</h1>",
-                    text: "Sure, I added the title for you. Do you want to add anything else?",
-                })
-            },
-            {
-                role: "user",
-                content: JSON.stringify({
-                    text: "Now make the title red and bold",
-                })
-            },
-            {
-                role: "assistant",
-                content: JSON.stringify({
-                    css: "h1 {\n\tcolor: red;\n\tfont-weight: bold;\n}",
-                    text: "Done! Now the title is red and bold.",
-                })
-            }
-        ];
+            messages: [
+                {
+                    role: 'system',
+                    content: buildSystemPrompt(),
+                },
+                ...buildMessages(messages),
+            ],
+        };
 
-
-        let sent_messages = [];
-        for (let message of messages) {
-
-            let message_json = {};
-            if (message.message) message_json.text = message.message;
-            if (message.html) message_json.html = message.html;
-            if (message.css) message_json.css = message.css;
-            if (message.js) message_json.js = message.js;
-
-            if (message.role === "system") continue;
-
-            if (message.role === "user" && message !== messages[messages.length - 1]) {
-                message_json = {
-                    text: message.message
-                };
-            }
-
-            if (message.role === "assistant") {
-            }
-
-            sent_messages.push({
-                role: message.role,
-                content: JSON.stringify(message_json)
-            });
-        }
-
-        let response = null;
         try {
-            response = await AI._OpenAIClient.createChatCompletion({
-                model: "gpt-3.5-turbo",
-                messages: [...prompt_and_examples, ...sent_messages],
+            const response = await fetch('https://api.openai.com/v1/chat/completions', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Authorization: `Bearer ${AI._apiKey}`,
+                },
+                body: JSON.stringify(requestBody),
             });
 
-            AI._totalUsedTokens += response.data.usage.total_tokens;
+            const data = await response.json();
 
-            if (response.data.choices[0].finish_reason === "length") {
-                return new ChatMessage("system", "The response message is incomplete due to the API's limitations. Please try again later.");
+            if (!response.ok) {
+                const errorCode = data?.error?.code;
+                const errorMessage = data?.error?.message;
+
+                if (response.status === 401) {
+                    return new ChatMessage('system', 'That API key was rejected. Please re-enter it and try again.');
+                }
+
+                if (response.status === 429) {
+                    return new ChatMessage('system', 'OpenAI rate-limited this request. Please wait a moment and try again.');
+                }
+
+                if (errorCode === 'context_length_exceeded' || response.status === 400) {
+                    return new ChatMessage('system', 'This request exceeded the model context window. Try a smaller request or trim the page content.');
+                }
+
+                return new ChatMessage('system', errorMessage || 'OpenAI returned an error. Please try again.');
             }
 
-            sent_messages.push({
-                role: "assistant",
-                content: response.data.choices[0].message.content,
-            });
+            const usage = data?.usage || {};
+            AI._totalUsage = {
+                inputTokens: AI._totalUsage.inputTokens + (usage.prompt_tokens || 0),
+                outputTokens: AI._totalUsage.outputTokens + (usage.completion_tokens || 0),
+                totalTokens: AI._totalUsage.totalTokens + (usage.total_tokens || 0),
+            };
 
+            const responseText = data?.choices?.[0]?.message?.content || '';
+            const responsePayload = sanitizeResponsePayload(extractJsonObject(responseText));
+
+            return new ChatMessage(
+                'assistant',
+                responsePayload.text,
+                responsePayload.html,
+                responsePayload.css,
+                responsePayload.js,
+            );
         } catch (error) {
             console.error(error);
-
-            if (error.response.status === 400) {
-                return new ChatMessage("system", "The response message is incomplete due to the API's limitations. Please try again later.");
-            }
-
-            else {
-                return new ChatMessage("system", "The API returned an error. Please try again later.");
-            }
+            return new ChatMessage('system', 'Something went wrong while contacting OpenAI. Check your network connection and try again.');
         }
-
-        let response_text = response.data.choices[0].message.content.trim();
-        let response_json = {};
-        try {
-            // Remove notes before and after the JSON object
-            if (response_text.includes("{") && response_text.includes("}")) {
-                response_text = response_text.substring(response_text.indexOf("{"), response_text.lastIndexOf("}") + 1);
-            }
-
-            response_json = JSON.parse(response_text);
-
-        } catch (error) {
-            
-            console.warn("The response message is not a valid JSON object. The message will be sent as a text message.")
-
-            response_json = {
-                text: response_text,
-			};
-        }
-
-        const newMessage = new ChatMessage(
-            "assistant",
-            response_json.text,
-            response_json.html,
-            response_json.css,
-            response_json.js
-        );
-
-        return newMessage;
     }
 }
 
+export { extractJsonObject, sanitizeResponsePayload, MODELS, STORAGE_KEYS };
 export default AI;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,5 +1,23 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+jest.mock('@shoelace-style/shoelace/dist/react', () => {
+  const React = require('react');
+
+  const passthrough = (tagName, defaultProps = {}) => {
+    return React.forwardRef(({ children, ...props }, ref) =>
+      React.createElement(tagName, { ref, ...defaultProps, ...props }, children),
+    );
+  };
+
+  return {
+    SlButton: passthrough('button'),
+    SlDialog: passthrough('div'),
+    SlInput: passthrough('input'),
+    SlSelect: passthrough('select'),
+    SlOption: passthrough('option'),
+    SlTooltip: passthrough('div'),
+    SlIcon: passthrough('span'),
+    SlBadge: passthrough('span'),
+    SlSpinner: passthrough('div'),
+  };
+});

--- a/src/styles/App.css
+++ b/src/styles/App.css
@@ -1,26 +1,75 @@
 .App * {
-	box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+body {
+  background: #0f172a;
 }
 
 .App {
-	height: 100vh;
-	width: 100vw;
-	position: relative;
+  height: 100vh;
+  width: 100vw;
+  position: relative;
 }
 
 .container {
-	position: relative;
-	height: 100%;
-	width: 100%;
-
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: center;
+  position: relative;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  justify-content: center;
 }
 
-.container>div {
-	height: 100%;
-	width: 100%;
-	min-width: 0;
+.container > div {
+  height: 100%;
+  width: 100%;
+  min-width: 0;
+}
+
+.sidebar-panel {
+  max-width: 420px;
+  display: flex;
+  flex-direction: column;
+  background: var(--color-background);
+}
+
+.settings-panel {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #1e293b;
+  border-left: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.settings-panel sl-select::part(combobox),
+.settings-panel sl-select::part(listbox) {
+  background: #0f172a;
+  color: white;
+}
+
+.settings-help {
+  margin: 0;
+  color: #cbd5e1;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.settings-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 1100px) {
+  .container {
+    flex-direction: column;
+  }
+
+  .sidebar-panel {
+    max-width: none;
+    min-height: 340px;
+  }
 }

--- a/src/styles/Chat.css
+++ b/src/styles/Chat.css
@@ -1,187 +1,161 @@
 .chat-container {
-	position: relative;
-	height: 100%;
-	width: 100%;
-	background-color: var(--color-background);
-
-	padding: 16px 8px;
+  position: relative;
+  height: 100%;
+  width: 100%;
+  background-color: var(--color-background);
+  padding: 8px 8px 16px;
 }
 
 .chat-container-inner {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-
-	position: relative;
-	height: 100%;
-	width: 100%;
-
-	background-color: var(--color-background-secondary);
-	border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  position: relative;
+  height: 100%;
+  width: 100%;
+  background-color: var(--color-background-secondary);
+  border-radius: 8px;
 }
 
 .chat-header {
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: flex-end;
-	gap: 8px;
-
-	padding: 16px;
-	z-index: 10;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 16px;
+  z-index: 10;
 }
 
 .chat-header sl-badge::part(base) {
-	background-color: #323741;
-	border: none;
-	padding: 8px 16px;
-	box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.2);
+  background-color: #323741;
+  border: none;
+  padding: 8px 16px;
+  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.2);
 }
 
 .chat-messages {
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-	justify-content: flex-end;
-	gap: 16px;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: flex-end;
+  gap: 16px;
+  position: relative;
+  height: calc(100% - 50px);
+  width: 100%;
+  padding: 72px 16px 0;
+  overflow-x: auto;
+  overflow-y: auto;
+}
 
-	position: relative;
-	height: calc(100% - 50px);
-	width: 100%;
-	padding: 0 16px;
-
-	overflow-x: auto;
-	overflow-y: auto;
+.chat-empty-state {
+  margin-top: auto;
+  padding: 16px;
+  border: 1px dashed rgba(255, 255, 255, 0.12);
+  border-radius: 12px;
+  color: #cbd5e1;
+  line-height: 1.6;
 }
 
 .chat-message {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-
-	position: relative;
-	height: auto;
-	width: auto;
-	max-width: 100%;
-	padding: 8px 16px;
-
-	background-color: var(--color-incoming-message-background);
-	color: var(--color-text);
-	border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  position: relative;
+  height: auto;
+  width: fit-content;
+  max-width: 100%;
+  padding: 10px 14px;
+  background-color: var(--color-incoming-message-background);
+  color: var(--color-text);
+  border-radius: 12px;
 }
 
 .chat-message.user {
-	background-color: #0284c7;
-	color: #fff;
-
-	border-top-left-radius: 0;
-	align-self: flex-start;
+  background-color: #0284c7;
+  color: #fff;
+  border-top-left-radius: 0;
+  align-self: flex-start;
 }
 
 .chat-message.assistant {
-	background-color: #323741;
-	color: #fff;
-
-	border-top-right-radius: 0;
-	align-self: flex-end;
+  background-color: #323741;
+  color: #fff;
+  border-top-right-radius: 0;
+  align-self: flex-end;
 }
 
 .chat-message.system {
-	background-color: #343e53;
-	color: #fff;
+  background-color: #343e53;
+  color: #fff;
+  max-width: 80%;
+  font-size: 14px;
+  align-self: center;
+}
 
-	max-width: 80%;
-	font-size: 14px;
-	align-self: center;
+.chat-message-role {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  opacity: 0.8;
 }
 
 .chat-message-content {
-	max-width: 100%;
-	overflow: hidden;
-	overflow-wrap: break-word;
+  max-width: 100%;
+  overflow: hidden;
+  overflow-wrap: break-word;
+  white-space: pre-wrap;
 }
 
 .chat-input {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-	padding: 8px 16px 20px 16px;
-
-	position: relative;
-	height: auto;
-	width: 100%;
-
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 16px 20px 16px;
+  position: relative;
+  height: auto;
+  width: 100%;
 }
 
-.chat-input>textarea {
-	width: 100%;
-	min-height: 40px;
-	max-height: 200px;
-
-	border: none;
-	border-radius: 20px;
-	resize: none;
-	background-color: #323741;
-	color: #fff;
-	padding: 8px 16px;
-	font-size: 16px;
-	font-family: 'Roboto', sans-serif;
+.chat-input > textarea {
+  width: 100%;
+  min-height: 48px;
+  max-height: 220px;
+  border: none;
+  border-radius: 20px;
+  resize: none;
+  background-color: #323741;
+  color: #fff;
+  padding: 12px 16px;
+  font-size: 16px;
+  font-family: 'Roboto', sans-serif;
 }
 
-.chat-input>textarea:focus {
-	outline: none;
+.chat-input > textarea:focus {
+  outline: none;
 }
 
-.chat-input>textarea[disabled] {
-	background-color: #2c313a;
-	color: #fff;
-	cursor: not-allowed;
+.chat-input > textarea[disabled] {
+  background-color: #2c313a;
+  color: #fff;
+  cursor: not-allowed;
 }
 
-/* scrollbar */
-.chat-input>textarea::-webkit-scrollbar {
-	width: 8px;
+.chat-input > textarea::-webkit-scrollbar {
+  width: 8px;
 }
 
-.chat-input>textarea::-webkit-scrollbar-thumb {
-	background-color: #555d6b;
-	border-radius: 4px;
-}
-
-.chat-input>button {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: center;
-	gap: 8px;
-
-	position: relative;
-	height: 100%;
-	width: 100px;
-	padding: 8px 16px;
-
-	border: none;
-
-	background-color: var(--color-button);
-	color: var(--color-text);
-	border-radius: 4px;
-
-	cursor: pointer;
-
-	user-select: none;
-}
-
-.chat-input>button:hover {
-	background-color: var(--color-button-hover);
+.chat-input > textarea::-webkit-scrollbar-thumb {
+  background-color: #555d6b;
+  border-radius: 4px;
 }


### PR DESCRIPTION
## Summary
- replace the legacy OpenAI SDK usage with a modern structured-output chat integration, selectable current models, and stronger prompt/error handling
- upgrade the product UX with a better starter template, browser-key guidance, model controls, reset flow, improved preview/export behavior, and richer usage tracking
- replace the broken placeholder test with coverage for the app shell and core AI/preview utilities, and refresh docs/dependencies

## Why
The app was still tied to the old OpenAI JS client, hardcoded to an outdated default model, and relied on brittle free-form JSON parsing with minimal recovery. This PR modernizes the core AI workflow while keeping the app as a static client-side experience.

## Approach
I kept the repo as a frontend-only app, but rewired the OpenAI integration around structured JSON-schema output over the chat completions API, added current model selection, and cleaned up the surrounding state management and UX so the changes are coherent rather than one-off patches.

## Test plan
- npm test
- npm run build

## Assumptions / tradeoffs
- The app still uses browser-side API keys because the product is designed as a static deployment; README now calls out the security tradeoff and suggests scoped keys/spend limits.
- Production builds still show a third-party Shoelace source-map warning from qr-creator, but the build completes successfully.