### PR TITLE
add tool-driven agent loop for editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,23 +6,23 @@ Live demo: https://csansoon.github.io/ai-web-designer/
 
 ## What's improved in this version
 
-- Upgraded the AI integration from the legacy OpenAI SDK flow to a modern structured-output chat integration.
-- Replaced the hardcoded `gpt-3.5-turbo` setup with selectable current models (`gpt-4.1-mini` and `gpt-4.1`).
-- Added stronger prompting and strict JSON schema responses so code updates are more reliable.
+- Replaced the old single-shot JSON schema flow with a tool-driven OpenAI Responses API loop.
+- Introduced explicit code-editing tools: `setHtml`, `setCss`, and `setJs`.
+- Kept the app frontend-only while making the AI editing flow more agentic and iterative.
+- Preserved model selection, API key management, and usage tracking from the previous branch.
 - Improved error handling for invalid keys, rate limits, networking failures, and context-length issues.
-- Added a better starter template, model picker, API key management UX, and more useful session usage tracking.
-- Replaced the broken starter test with app- and utility-level coverage.
+- Added tests for the new orchestration helpers and multi-step tool loop.
 
 ## How it works
 
-The assistant receives the latest user request together with the current HTML, CSS, and JavaScript state of the page. It returns structured JSON containing:
+The app sends the current conversation plus the latest HTML, CSS, and JavaScript artifacts to the OpenAI Responses API. Instead of returning one giant JSON blob, the model works through a local tool loop:
 
-- `text`: the assistant reply shown in chat
-- `html`: optional replacement body markup
-- `css`: optional replacement stylesheet
-- `js`: optional replacement JavaScript
+1. The model reads the current page state and the latest user request.
+2. It calls browser-defined tools such as `setHtml`, `setCss`, and `setJs` whenever it wants to update an artifact.
+3. The app applies each tool call locally, records the operation in chat history, and sends the tool results back to the model.
+4. The loop continues until the model stops calling tools and returns a final assistant summary for the user.
 
-Only the changed parts need to be returned, which keeps iteration fast and makes the app feel more like an AI design copilot than a single-shot generator.
+This architecture makes edits more explainable, better matches modern agent/tool workflows, and keeps the code generation logic understandable in a static client-side app.
 
 ## Local development
 
@@ -54,4 +54,5 @@ A future backend proxy could further improve security and observability, but thi
 
 - The app is optimized for a single static page rather than full multi-page apps.
 - Very large HTML/CSS/JS payloads can still hit model context limits.
+- Tool calls currently replace entire artifacts rather than patching subsections in place.
 - Browser-side API usage is convenient for demos, but a server-side proxy is safer for production deployments.

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
-import { extractJsonObject, sanitizeResponsePayload } from './model/AI';
 import { buildPreviewDocument } from './components/VirtualPage';
 
 beforeEach(() => {
@@ -18,19 +17,6 @@ test('renders model selector and starter guidance', () => {
   expect(screen.getByText(/describe the page you want to build/i)).toBeInTheDocument();
   expect(screen.getAllByText(/gpt-4.1-mini/i).length).toBeGreaterThan(0);
   expect(screen.getByText(/reset starter/i)).toBeInTheDocument();
-});
-
-test('extractJsonObject trims wrapper text', () => {
-  expect(extractJsonObject('note {"text":"hello"} thanks')).toEqual({ text: 'hello' });
-});
-
-test('sanitizeResponsePayload ensures text exists', () => {
-  expect(sanitizeResponsePayload({ html: '<h1>Hi</h1>' })).toEqual({
-    text: 'Done.',
-    html: '<h1>Hi</h1>',
-    css: undefined,
-    js: undefined,
-  });
 });
 
 test('buildPreviewDocument creates complete HTML document', () => {

--- a/src/components/ChatMessage.js
+++ b/src/components/ChatMessage.js
@@ -1,10 +1,11 @@
 class ChatMessage {
-  constructor(role, message, html, css, js) {
+  constructor(role, message, html, css, js, operations = []) {
     this.role = role;
     this.message = message;
     this.html = html;
     this.css = css;
     this.js = js;
+    this.operations = Array.isArray(operations) ? operations : [];
   }
 
   render(key) {
@@ -12,6 +13,15 @@ class ChatMessage {
       <div className={`chat-message ${this.role}`} key={key}>
         <div className="chat-message-role">{this.role === 'assistant' ? 'AI' : this.role === 'user' ? 'You' : 'System'}</div>
         <div className="chat-message-content">{this.message}</div>
+        {this.operations.length > 0 && (
+          <div className="chat-message-operations">
+            {this.operations.map((operation, index) => (
+              <div className="chat-message-operation" key={`${operation.tool}-${index}`}>
+                {operation.label || operation.tool}
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/model/AI.js
+++ b/src/model/AI.js
@@ -1,265 +1,302 @@
 import ChatMessage from '../components/ChatMessage';
+import { ARTIFACT_TOOL_DEFINITIONS, applyArtifactToolCall } from './artifactTools';
 
 const STORAGE_KEYS = {
-    apiKey: 'api_key',
-    selectedModel: 'selected_model',
+  apiKey: 'api_key',
+  selectedModel: 'selected_model',
 };
 
 const MODELS = {
-    'gpt-4.1-mini': {
-        label: 'gpt-4.1-mini',
-        inputCostPerMillion: 0.4,
-        outputCostPerMillion: 1.6,
-        description: 'Fast default for iterative web design edits.',
-    },
-    'gpt-4.1': {
-        label: 'gpt-4.1',
-        inputCostPerMillion: 2,
-        outputCostPerMillion: 8,
-        description: 'Higher quality for larger or trickier page rewrites.',
-    },
+  'gpt-4.1-mini': {
+    label: 'gpt-4.1-mini',
+    inputCostPerMillion: 0.4,
+    outputCostPerMillion: 1.6,
+    description: 'Fast default for iterative web design edits.',
+  },
+  'gpt-4.1': {
+    label: 'gpt-4.1',
+    inputCostPerMillion: 2,
+    outputCostPerMillion: 8,
+    description: 'Higher quality for larger or trickier page rewrites.',
+  },
 };
 
-const RESPONSE_SCHEMA = {
-    name: 'web_designer_response',
-    schema: {
-        type: 'object',
-        additionalProperties: false,
-        properties: {
-            text: {
-                type: 'string',
-                description: 'A concise explanation of what changed or what is needed from the user.',
-            },
-            html: {
-                type: 'string',
-                description: 'Replacement HTML for the body content only.',
-            },
-            css: {
-                type: 'string',
-                description: 'Replacement CSS for the page.',
-            },
-            js: {
-                type: 'string',
-                description: 'Replacement JavaScript for the page.',
-            },
-        },
-        required: ['text'],
-    },
-    strict: true,
-};
-
-function extractJsonObject(text) {
-    if (!text || typeof text !== 'string') {
-        throw new Error('Missing response text');
-    }
-
-    const start = text.indexOf('{');
-    const end = text.lastIndexOf('}');
-
-    if (start === -1 || end === -1 || end < start) {
-        throw new Error('Response did not contain JSON');
-    }
-
-    return JSON.parse(text.slice(start, end + 1));
-}
-
-function sanitizeResponsePayload(payload) {
-    const parsed = payload || {};
-
-    return {
-        text: typeof parsed.text === 'string' && parsed.text.trim() ? parsed.text.trim() : 'Done.',
-        html: typeof parsed.html === 'string' ? parsed.html : undefined,
-        css: typeof parsed.css === 'string' ? parsed.css : undefined,
-        js: typeof parsed.js === 'string' ? parsed.js : undefined,
-    };
-}
+const MAX_TOOL_ROUNDS = 8;
 
 function buildSystemPrompt() {
-    return [
-        'You are an expert AI web designer embedded inside a browser-based HTML/CSS/JS editor.',
-        'Your job is to help users iteratively design a single static web page.',
-        'You will receive JSON from the user with these fields when available: text, html, css, js.',
-        'The html field always represents the contents of the <body> tag only. Never add <html>, <head>, or <body> wrappers.',
-        'Return valid JSON that matches the required schema.',
-        'Always include the text field.',
-        'Only include html, css, or js when you want to replace that part of the current page.',
-        'Keep code readable and production-like. Prefer semantic HTML, modern CSS, and unobtrusive JavaScript.',
-        'If the user asks for something unsafe or impossible in a static page, explain that in text and provide the closest safe alternative.',
-        'When updating code, preserve existing good work unless the user asked for a redesign.',
-    ].join('\n');
+  return [
+    'You are an expert AI web designer embedded inside a browser-based HTML/CSS/JS editor.',
+    'Your job is to iteratively design a single static web page.',
+    'The latest user message includes the current page state as JSON with text, html, css, and js fields.',
+    'Use the available tools to update code. Do not paste large HTML, CSS, or JavaScript directly into assistant messages.',
+    'When you need to change markup, styles, or behavior, call setHtml, setCss, and setJs with complete replacement code for that artifact.',
+    'You may call multiple tools in a single turn. Keep running until the page is updated, then send a concise user-facing summary.',
+    'The html artifact always represents the contents of the <body> tag only. Never add <html>, <head>, or <body> wrappers.',
+    'Keep code readable and production-like. Prefer semantic HTML, modern CSS, and unobtrusive JavaScript.',
+    'If the user asks for something unsafe or impossible in a static page, explain that in the final summary and provide the closest safe alternative.',
+    'Preserve existing good work unless the user asked for a redesign.',
+  ].join('\n');
 }
 
-function buildMessages(messages) {
-    return messages
-        .filter((message) => message.role !== 'system')
-        .map((message, index) => {
-            let payload = {};
+function buildAssistantHistoryPayload(message) {
+  return {
+    text: message.message,
+    operations: (message.operations || []).map((operation) => ({
+      tool: operation.tool,
+      target: operation.target,
+      reason: operation.reason,
+    })),
+  };
+}
 
-            if (message.role === 'user') {
-                if (index === messages.length - 1) {
-                    payload = {
-                        text: message.message,
-                        html: message.html || '',
-                        css: message.css || '',
-                        js: message.js || '',
-                    };
-                } else {
-                    payload = {
-                        text: message.message,
-                    };
-                }
-            } else {
-                payload = sanitizeResponsePayload({
-                    text: message.message,
-                    html: message.html,
-                    css: message.css,
-                    js: message.js,
-                });
+function buildResponsesInput(messages) {
+  return messages
+    .filter((message) => message.role !== 'system')
+    .map((message, index) => {
+      const isLatest = index === messages.length - 1;
+      let payload;
+
+      if (message.role === 'user') {
+        payload = isLatest
+          ? {
+              text: message.message,
+              html: message.html || '',
+              css: message.css || '',
+              js: message.js || '',
             }
-
-            return {
-                role: message.role,
-                content: JSON.stringify(payload),
+          : {
+              text: message.message,
             };
-        });
+      } else {
+        payload = buildAssistantHistoryPayload(message);
+      }
+
+      return {
+        role: message.role,
+        content: [
+          {
+            type: 'input_text',
+            text: JSON.stringify(payload),
+          },
+        ],
+      };
+    });
+}
+
+function getLatestArtifacts(messages) {
+  const latestUserMessage = [...messages].reverse().find((message) => message.role === 'user');
+
+  return {
+    html: latestUserMessage?.html || '',
+    css: latestUserMessage?.css || '',
+    js: latestUserMessage?.js || '',
+  };
+}
+
+function extractAssistantText(responsePayload) {
+  if (typeof responsePayload?.output_text === 'string' && responsePayload.output_text.trim()) {
+    return responsePayload.output_text.trim();
+  }
+
+  const messageTexts = [];
+
+  for (const item of responsePayload?.output || []) {
+    if (item.type !== 'message' || !Array.isArray(item.content)) {
+      continue;
+    }
+
+    for (const contentItem of item.content) {
+      if (contentItem.type === 'output_text' && typeof contentItem.text === 'string' && contentItem.text.trim()) {
+        messageTexts.push(contentItem.text.trim());
+      }
+    }
+  }
+
+  return messageTexts.join('\n\n').trim();
+}
+
+function extractFunctionCalls(responsePayload) {
+  return (responsePayload?.output || []).filter((item) => item.type === 'function_call');
+}
+
+function buildFunctionCallOutput(callId, output) {
+  return {
+    type: 'function_call_output',
+    call_id: callId,
+    output: JSON.stringify(output),
+  };
+}
+
+function updateUsage(usage) {
+  AI._totalUsage = {
+    inputTokens: AI._totalUsage.inputTokens + (usage?.input_tokens || 0),
+    outputTokens: AI._totalUsage.outputTokens + (usage?.output_tokens || 0),
+    totalTokens: AI._totalUsage.totalTokens + (usage?.total_tokens || 0),
+  };
+}
+
+function buildSummaryFallback(operations) {
+  if (operations.length === 0) {
+    return 'Done.';
+  }
+
+  const toolNames = operations.map((operation) => operation.tool).join(', ');
+  return `Applied updates with ${toolNames}.`;
 }
 
 class AI {
-    static _apiKey = null;
-    static _totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  static _apiKey = null;
+  static _totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
 
-    static initWithKey(key) {
-        AI._apiKey = key;
-        AI._totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  static initWithKey(key) {
+    AI._apiKey = key;
+    AI._totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  }
+
+  static clear() {
+    AI._apiKey = null;
+    AI._totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  }
+
+  static get isInitialized() {
+    return Boolean(AI._apiKey);
+  }
+
+  static get availableModels() {
+    return MODELS;
+  }
+
+  static getSelectedModel() {
+    return localStorage.getItem(STORAGE_KEYS.selectedModel) || 'gpt-4.1-mini';
+  }
+
+  static setSelectedModel(model) {
+    if (!MODELS[model]) {
+      throw new Error(`Unsupported model: ${model}`);
     }
 
-    static clear() {
-        AI._apiKey = null;
-        AI._totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    localStorage.setItem(STORAGE_KEYS.selectedModel, model);
+  }
+
+  static async checkAPIKey(key) {
+    try {
+      const response = await fetch('https://api.openai.com/v1/models', {
+        headers: {
+          Authorization: `Bearer ${key}`,
+        },
+      });
+
+      return response.ok;
+    } catch (error) {
+      console.error(error);
+      return false;
+    }
+  }
+
+  static get totalUsedTokens() {
+    return AI._totalUsage.totalTokens;
+  }
+
+  static get totalUsedTokensUSD() {
+    const pricing = MODELS[AI.getSelectedModel()] || MODELS['gpt-4.1-mini'];
+    const inputCost = (AI._totalUsage.inputTokens / 1_000_000) * pricing.inputCostPerMillion;
+    const outputCost = (AI._totalUsage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
+    return inputCost + outputCost;
+  }
+
+  static async getResponseMessage(messages) {
+    if (!AI.isInitialized) {
+      return new ChatMessage('system', 'Add a valid OpenAI API key to start generating pages.');
     }
 
-    static get isInitialized() {
-        return Boolean(AI._apiKey);
-    }
+    const model = AI.getSelectedModel();
+    const startingArtifacts = getLatestArtifacts(messages);
+    const nextArtifacts = { ...startingArtifacts };
+    const operations = [];
+    const input = buildResponsesInput(messages);
 
-    static get availableModels() {
-        return MODELS;
-    }
-
-    static getSelectedModel() {
-        return localStorage.getItem(STORAGE_KEYS.selectedModel) || 'gpt-4.1-mini';
-    }
-
-    static setSelectedModel(model) {
-        if (!MODELS[model]) {
-            throw new Error(`Unsupported model: ${model}`);
-        }
-
-        localStorage.setItem(STORAGE_KEYS.selectedModel, model);
-    }
-
-    static async checkAPIKey(key) {
-        try {
-            const response = await fetch('https://api.openai.com/v1/models', {
-                headers: {
-                    Authorization: `Bearer ${key}`,
-                },
-            });
-
-            return response.ok;
-        } catch (error) {
-            console.error(error);
-            return false;
-        }
-    }
-
-    static get totalUsedTokens() {
-        return AI._totalUsage.totalTokens;
-    }
-
-    static get totalUsedTokensUSD() {
-        const pricing = MODELS[AI.getSelectedModel()] || MODELS['gpt-4.1-mini'];
-        const inputCost = (AI._totalUsage.inputTokens / 1_000_000) * pricing.inputCostPerMillion;
-        const outputCost = (AI._totalUsage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
-        return inputCost + outputCost;
-    }
-
-    static async getResponseMessage(messages) {
-        if (!AI.isInitialized) {
-            return new ChatMessage('system', 'Add a valid OpenAI API key to start generating pages.');
-        }
-
-        const model = AI.getSelectedModel();
-        const requestBody = {
+    try {
+      for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
+        const response = await fetch('https://api.openai.com/v1/responses', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${AI._apiKey}`,
+          },
+          body: JSON.stringify({
             model,
             temperature: 0.3,
-            response_format: {
-                type: 'json_schema',
-                json_schema: RESPONSE_SCHEMA,
-            },
-            messages: [
-                {
-                    role: 'system',
-                    content: buildSystemPrompt(),
-                },
-                ...buildMessages(messages),
-            ],
-        };
+            store: false,
+            instructions: buildSystemPrompt(),
+            tools: ARTIFACT_TOOL_DEFINITIONS,
+            input,
+          }),
+        });
 
-        try {
-            const response = await fetch('https://api.openai.com/v1/chat/completions', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    Authorization: `Bearer ${AI._apiKey}`,
-                },
-                body: JSON.stringify(requestBody),
-            });
+        const data = await response.json();
 
-            const data = await response.json();
+        if (!response.ok) {
+          const errorCode = data?.error?.code;
+          const errorMessage = data?.error?.message;
 
-            if (!response.ok) {
-                const errorCode = data?.error?.code;
-                const errorMessage = data?.error?.message;
+          if (response.status === 401) {
+            return new ChatMessage('system', 'That API key was rejected. Please re-enter it and try again.');
+          }
 
-                if (response.status === 401) {
-                    return new ChatMessage('system', 'That API key was rejected. Please re-enter it and try again.');
-                }
+          if (response.status === 429) {
+            return new ChatMessage('system', 'OpenAI rate-limited this request. Please wait a moment and try again.');
+          }
 
-                if (response.status === 429) {
-                    return new ChatMessage('system', 'OpenAI rate-limited this request. Please wait a moment and try again.');
-                }
+          if (errorCode === 'context_length_exceeded' || response.status === 400) {
+            return new ChatMessage('system', 'This request exceeded the model context window. Try a smaller request or trim the page content.');
+          }
 
-                if (errorCode === 'context_length_exceeded' || response.status === 400) {
-                    return new ChatMessage('system', 'This request exceeded the model context window. Try a smaller request or trim the page content.');
-                }
-
-                return new ChatMessage('system', errorMessage || 'OpenAI returned an error. Please try again.');
-            }
-
-            const usage = data?.usage || {};
-            AI._totalUsage = {
-                inputTokens: AI._totalUsage.inputTokens + (usage.prompt_tokens || 0),
-                outputTokens: AI._totalUsage.outputTokens + (usage.completion_tokens || 0),
-                totalTokens: AI._totalUsage.totalTokens + (usage.total_tokens || 0),
-            };
-
-            const responseText = data?.choices?.[0]?.message?.content || '';
-            const responsePayload = sanitizeResponsePayload(extractJsonObject(responseText));
-
-            return new ChatMessage(
-                'assistant',
-                responsePayload.text,
-                responsePayload.html,
-                responsePayload.css,
-                responsePayload.js,
-            );
-        } catch (error) {
-            console.error(error);
-            return new ChatMessage('system', 'Something went wrong while contacting OpenAI. Check your network connection and try again.');
+          return new ChatMessage('system', errorMessage || 'OpenAI returned an error. Please try again.');
         }
+
+        updateUsage(data?.usage);
+        input.push(...(data?.output || []));
+
+        const functionCalls = extractFunctionCalls(data);
+
+        if (functionCalls.length === 0) {
+          const summary = extractAssistantText(data) || buildSummaryFallback(operations);
+
+          return new ChatMessage(
+            'assistant',
+            summary,
+            nextArtifacts.html !== startingArtifacts.html ? nextArtifacts.html : undefined,
+            nextArtifacts.css !== startingArtifacts.css ? nextArtifacts.css : undefined,
+            nextArtifacts.js !== startingArtifacts.js ? nextArtifacts.js : undefined,
+            operations,
+          );
+        }
+
+        for (const functionCall of functionCalls) {
+          const result = applyArtifactToolCall(functionCall.name, functionCall.arguments, nextArtifacts);
+
+          if (result.operation) {
+            operations.push(result.operation);
+          }
+
+          input.push(buildFunctionCallOutput(functionCall.call_id || functionCall.id, result.output));
+        }
+      }
+
+      return new ChatMessage('system', 'The AI editor exceeded the tool-call limit for this request. Try a smaller change.');
+    } catch (error) {
+      console.error(error);
+      return new ChatMessage('system', 'Something went wrong while contacting OpenAI. Check your network connection and try again.');
     }
+  }
 }
 
-export { extractJsonObject, sanitizeResponsePayload, MODELS, STORAGE_KEYS };
+export {
+  buildResponsesInput,
+  buildAssistantHistoryPayload,
+  extractAssistantText,
+  extractFunctionCalls,
+  MODELS,
+  STORAGE_KEYS,
+};
 export default AI;

--- a/src/model/AI.test.js
+++ b/src/model/AI.test.js
@@ -1,0 +1,171 @@
+import AI, {
+  buildAssistantHistoryPayload,
+  buildResponsesInput,
+  extractAssistantText,
+  extractFunctionCalls,
+} from './AI';
+import ChatMessage from '../components/ChatMessage';
+import { applyArtifactToolCall } from './artifactTools';
+
+describe('AI helpers', () => {
+  afterEach(() => {
+    AI.clear();
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  test('buildAssistantHistoryPayload preserves operation summaries', () => {
+    const payload = buildAssistantHistoryPayload(
+      new ChatMessage('assistant', 'Updated the layout.', undefined, undefined, undefined, [
+        { tool: 'setHtml', target: 'html', reason: 'Add a hero section' },
+      ]),
+    );
+
+    expect(payload).toEqual({
+      text: 'Updated the layout.',
+      operations: [
+        { tool: 'setHtml', target: 'html', reason: 'Add a hero section' },
+      ],
+    });
+  });
+
+  test('buildResponsesInput includes the latest artifact state for the newest user message', () => {
+    const input = buildResponsesInput([
+      new ChatMessage('user', 'Create a page'),
+      new ChatMessage('assistant', 'Done.', undefined, undefined, undefined, [
+        { tool: 'setHtml', target: 'html', reason: 'Initial structure' },
+      ]),
+      new ChatMessage('user', 'Refine it', '<main>Current</main>', '.page{}', 'console.log("x")'),
+    ]);
+
+    expect(input).toEqual([
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: JSON.stringify({ text: 'Create a page' }) }],
+      },
+      {
+        role: 'assistant',
+        content: [{ type: 'input_text', text: JSON.stringify({
+          text: 'Done.',
+          operations: [{ tool: 'setHtml', target: 'html', reason: 'Initial structure' }],
+        }) }],
+      },
+      {
+        role: 'user',
+        content: [{ type: 'input_text', text: JSON.stringify({
+          text: 'Refine it',
+          html: '<main>Current</main>',
+          css: '.page{}',
+          js: 'console.log("x")',
+        }) }],
+      },
+    ]);
+  });
+
+  test('extractAssistantText reads message output text', () => {
+    expect(extractAssistantText({
+      output: [
+        {
+          type: 'message',
+          content: [
+            { type: 'output_text', text: 'Applied the redesign.' },
+          ],
+        },
+      ],
+    })).toBe('Applied the redesign.');
+  });
+
+  test('extractFunctionCalls finds tool invocations', () => {
+    expect(extractFunctionCalls({
+      output: [
+        { type: 'function_call', name: 'setHtml' },
+        { type: 'message' },
+      ],
+    })).toEqual([{ type: 'function_call', name: 'setHtml' }]);
+  });
+
+  test('applyArtifactToolCall updates artifacts and returns an operation summary', () => {
+    const artifacts = { html: '<main>Old</main>', css: '', js: '' };
+    const result = applyArtifactToolCall('setHtml', JSON.stringify({
+      html: '<main>New</main>',
+      reason: 'Swap in the updated layout',
+    }), artifacts);
+
+    expect(result.ok).toBe(true);
+    expect(artifacts.html).toBe('<main>New</main>');
+    expect(result.operation).toEqual(expect.objectContaining({
+      tool: 'setHtml',
+      target: 'html',
+      reason: 'Swap in the updated layout',
+    }));
+  });
+});
+
+describe('AI tool loop', () => {
+  afterEach(() => {
+    AI.clear();
+    jest.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  test('getResponseMessage applies tool calls until the assistant returns a summary', async () => {
+    AI.initWithKey('test-key');
+    localStorage.setItem('selected_model', 'gpt-4.1-mini');
+
+    const fetchSpy = jest.spyOn(global, 'fetch')
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          usage: { input_tokens: 120, output_tokens: 30, total_tokens: 150 },
+          output: [
+            {
+              type: 'function_call',
+              id: 'fc_1',
+              call_id: 'call_1',
+              name: 'setHtml',
+              arguments: JSON.stringify({
+                html: '<main><h1>New hero</h1></main>',
+                reason: 'Replace the old hero section',
+              }),
+            },
+            {
+              type: 'function_call',
+              id: 'fc_2',
+              call_id: 'call_2',
+              name: 'setCss',
+              arguments: JSON.stringify({
+                css: 'body { color: red; }',
+                reason: 'Match the new hero styling',
+              }),
+            },
+          ],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          usage: { input_tokens: 80, output_tokens: 20, total_tokens: 100 },
+          output_text: 'Updated the hero markup and styling.',
+          output: [
+            {
+              type: 'message',
+              content: [{ type: 'output_text', text: 'Updated the hero markup and styling.' }],
+            },
+          ],
+        }),
+      });
+
+    const responseMessage = await AI.getResponseMessage([
+      new ChatMessage('user', 'Refresh the hero section.', '<main>Old</main>', 'body { color: blue; }', ''),
+    ]);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(responseMessage.role).toBe('assistant');
+    expect(responseMessage.message).toBe('Updated the hero markup and styling.');
+    expect(responseMessage.html).toBe('<main><h1>New hero</h1></main>');
+    expect(responseMessage.css).toBe('body { color: red; }');
+    expect(responseMessage.js).toBeUndefined();
+    expect(responseMessage.operations).toHaveLength(2);
+    expect(AI.totalUsedTokens).toBe(250);
+  });
+});

--- a/src/model/artifactTools.js
+++ b/src/model/artifactTools.js
@@ -1,0 +1,142 @@
+const ARTIFACT_TOOL_DEFINITIONS = [
+  {
+    type: 'function',
+    name: 'setHtml',
+    description: 'Replace the current page HTML with a complete new body fragment. Do not include <html>, <head>, or <body> tags.',
+    strict: true,
+    parameters: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        html: {
+          type: 'string',
+          description: 'The full replacement HTML for the contents of the <body> tag.',
+        },
+        reason: {
+          type: 'string',
+          description: 'Short explanation of why this update is needed.',
+        },
+      },
+      required: ['html'],
+    },
+  },
+  {
+    type: 'function',
+    name: 'setCss',
+    description: 'Replace the current stylesheet with a complete new version.',
+    strict: true,
+    parameters: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        css: {
+          type: 'string',
+          description: 'The full replacement CSS for the page.',
+        },
+        reason: {
+          type: 'string',
+          description: 'Short explanation of why this update is needed.',
+        },
+      },
+      required: ['css'],
+    },
+  },
+  {
+    type: 'function',
+    name: 'setJs',
+    description: 'Replace the current JavaScript with a complete new version.',
+    strict: true,
+    parameters: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        js: {
+          type: 'string',
+          description: 'The full replacement JavaScript for the page.',
+        },
+        reason: {
+          type: 'string',
+          description: 'Short explanation of why this update is needed.',
+        },
+      },
+      required: ['js'],
+    },
+  },
+];
+
+const TOOL_TARGETS = {
+  setHtml: 'html',
+  setCss: 'css',
+  setJs: 'js',
+};
+
+function createOperation(tool, value, reason) {
+  const suffix = reason ? `: ${reason.trim()}` : '';
+
+  return {
+    tool,
+    target: TOOL_TARGETS[tool],
+    reason: typeof reason === 'string' ? reason.trim() : '',
+    label: `${tool}${suffix}`,
+    size: typeof value === 'string' ? value.length : 0,
+  };
+}
+
+function applyArtifactToolCall(toolName, rawArguments, artifacts) {
+  const target = TOOL_TARGETS[toolName];
+
+  if (!target) {
+    return {
+      ok: false,
+      operation: null,
+      output: {
+        ok: false,
+        error: `Unsupported tool: ${toolName}`,
+      },
+    };
+  }
+
+  let parsedArguments;
+
+  try {
+    parsedArguments = typeof rawArguments === 'string' ? JSON.parse(rawArguments) : rawArguments;
+  } catch (error) {
+    return {
+      ok: false,
+      operation: null,
+      output: {
+        ok: false,
+        error: `Invalid JSON arguments for ${toolName}.`,
+      },
+    };
+  }
+
+  const nextValue = parsedArguments?.[target];
+
+  if (typeof nextValue !== 'string') {
+    return {
+      ok: false,
+      operation: null,
+      output: {
+        ok: false,
+        error: `${toolName} requires a string "${target}" field.`,
+      },
+    };
+  }
+
+  const reason = typeof parsedArguments.reason === 'string' ? parsedArguments.reason : '';
+
+  artifacts[target] = nextValue;
+
+  return {
+    ok: true,
+    operation: createOperation(toolName, nextValue, reason),
+    output: {
+      ok: true,
+      target,
+      size: nextValue.length,
+    },
+  };
+}
+
+export { ARTIFACT_TOOL_DEFINITIONS, applyArtifactToolCall };

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -4,9 +4,28 @@ jest.mock('@shoelace-style/shoelace/dist/react', () => {
   const React = require('react');
 
   const passthrough = (tagName, defaultProps = {}) => {
-    return React.forwardRef(({ children, ...props }, ref) =>
-      React.createElement(tagName, { ref, ...defaultProps, ...props }, children),
-    );
+    return React.forwardRef(({ children, onSlInput, onSlChange, onSlRequestClose, loading, hoist, circle, ...props }, ref) => {
+      const normalizedProps = {
+        ref,
+        ...defaultProps,
+        ...props,
+      };
+
+      if (onSlInput) {
+        normalizedProps.onInput = onSlInput;
+        normalizedProps.onChange = onSlInput;
+      }
+
+      if (onSlChange) {
+        normalizedProps.onChange = onSlChange;
+      }
+
+      if (tagName === 'input' || tagName === 'select') {
+        normalizedProps.readOnly = normalizedProps.onChange ? undefined : true;
+      }
+
+      return React.createElement(tagName, normalizedProps, children);
+    });
   };
 
   return {

--- a/src/styles/Chat.css
+++ b/src/styles/Chat.css
@@ -115,6 +115,22 @@
   white-space: pre-wrap;
 }
 
+.chat-message-operations {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.chat-message-operation {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background-color: rgba(255, 255, 255, 0.12);
+  font-size: 11px;
+  line-height: 1.2;
+  letter-spacing: 0.01em;
+}
+
 .chat-input {
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
## Summary
- replace the single-shot structured output flow with a Responses API tool loop that applies `setHtml`, `setCss`, and `setJs` locally until the model stops calling tools
- record applied artifact operations in assistant messages and cover the orchestration helpers/tool loop with focused tests
- update the README to explain the new tool-driven architecture and its current tradeoffs in this frontend-only app

## Why
PR #9 modernized the stack, but the app still depended on one large response payload returning all code at once. This follow-up shifts the generation flow toward current agentic patterns so iterative page editing is more explicit, explainable, and maintainable.

## Approach
I kept the product frontend-only and moved the core generation logic to a small Responses API orchestration loop in `src/model/AI.js`. The model now edits artifacts through explicit tools and returns a final user-facing summary after local tool execution instead of stuffing HTML/CSS/JS into one schema response.

## Test plan
- npm test -- --watchAll=false
- npm run build

## Assumptions / tradeoffs
- This keeps whole-artifact replacement tools (`setHtml`, `setCss`, `setJs`) instead of adding brittle subsection patching before the repo has stronger parsing and conflict-management primitives.
- The production build still emits the existing third-party `qr-creator` source-map warning, but it completes successfully.
