### PR TITLE
fix shoelace production runtime regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ai-web-designer",
       "version": "0.1.0",
       "dependencies": {
-        "@shoelace-style/shoelace": "^2.20.1",
+        "@shoelace-style/shoelace": "2.2.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -18,8 +18,7 @@
         "react-scripts": "5.0.1",
         "react-textarea-autosize": "^8.5.9",
         "web-vitals": "^2.1.4"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@adobe/css-tools": {
       "version": "4.2.0",
@@ -2222,12 +2221,12 @@
       }
     },
     "node_modules/@ctrl/tinycolor": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-4.2.0.tgz",
-      "integrity": "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=10"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -3128,28 +3127,25 @@
         "@lezer/common": "^1.0.0"
       }
     },
+    "node_modules/@lit-labs/react": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/react/-/react-1.2.1.tgz",
+      "integrity": "sha512-DiZdJYFU0tBbdQkfwwRSwYyI/mcWkg3sWesKRsHUd4G+NekTmmeq9fzsurvcKTNVa0comNljwtg4Hvi1ds3V+A==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.5.1.tgz",
       "integrity": "sha512-Aou5UdlSpr5whQe8AA/bZG0jMj96CoJIWbGfZ91qieWu5AWUMKw8VR/pAkQkJYvBNhmCcWnZlyyk5oze8JIqYA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@lit/react": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@lit/react/-/react-1.0.8.tgz",
-      "integrity": "sha512-p2+YcF+JE67SRX3mMlJ1TKCSTsgyOVdAwd/nxp3NuV1+Cb6MWALbN6nT7Ld4tpmYofcE5kcaSY1YBB9erY+6fw==",
-      "license": "BSD-3-Clause",
-      "peerDependencies": {
-        "@types/react": "17 || 18 || 19"
-      }
-    },
     "node_modules/@lit/reactive-element": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.2.tgz",
-      "integrity": "sha512-pbCDiVMnne1lYUIaYNN5wrwQXDtHaYtg7YEFPeW+hws6U47WeFvISGUWekPGKWOP1ygrs0ef0o1VJMk1exos5A==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
+      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.5.0"
+        "@lit-labs/ssr-dom-shim": "^1.0.0"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -3357,18 +3353,18 @@
       "license": "MIT"
     },
     "node_modules/@shoelace-style/shoelace": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.20.1.tgz",
-      "integrity": "sha512-FSghU95jZPGbwr/mybVvk66qRZYpx5FkXL+vLNpy1Vp8UsdwSxXjIHE3fsvMbKWTKi9UFfewHTkc5e7jAqRYoQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@shoelace-style/shoelace/-/shoelace-2.2.0.tgz",
+      "integrity": "sha512-53do7etYwygRRnx1tt5SPGfTL8YFtZVNTlfn5Tabno66otBXROKnUjWVqyLRP6xvj6BG6BP62DkZQG6pxIDMVg==",
       "license": "MIT",
       "dependencies": {
-        "@ctrl/tinycolor": "^4.1.0",
-        "@floating-ui/dom": "^1.6.12",
-        "@lit/react": "^1.0.6",
-        "@shoelace-style/animations": "^1.2.0",
-        "@shoelace-style/localize": "^3.2.1",
-        "composed-offset-position": "^0.0.6",
-        "lit": "^3.2.1",
+        "@ctrl/tinycolor": "^3.5.0",
+        "@floating-ui/dom": "^1.2.1",
+        "@lit-labs/react": "^1.1.1",
+        "@shoelace-style/animations": "^1.1.0",
+        "@shoelace-style/localize": "^3.1.0",
+        "composed-offset-position": "^0.0.4",
+        "lit": "^2.6.1",
         "qr-creator": "^1.0.0"
       },
       "engines": {
@@ -6109,13 +6105,10 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="
     },
     "node_modules/composed-offset-position": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.6.tgz",
-      "integrity": "sha512-Q7dLompI6lUwd7LWyIcP66r4WcS9u7AL2h8HaeipiRfCRPLMWqRx8fYsjb4OHi6UQFifO7XtNC2IlEJ1ozIFxw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@floating-ui/utils": "^0.2.5"
-      }
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/composed-offset-position/-/composed-offset-position-0.0.4.tgz",
+      "integrity": "sha512-vMlvu1RuNegVE0YsCDSV/X4X10j56mq7PCIyOKK74FxkXzGLwhOUmdkJLSdOBOMwWycobGUMgft2lp+YgTe8hw==",
+      "license": "MIT"
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -12033,31 +12026,31 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/lit": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.2.tgz",
-      "integrity": "sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
+      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^2.1.0",
-        "lit-element": "^4.2.0",
-        "lit-html": "^3.3.0"
+        "@lit/reactive-element": "^1.6.0",
+        "lit-element": "^3.3.0",
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.2.tgz",
-      "integrity": "sha512-aFKhNToWxoyhkNDmWZwEva2SlQia+jfG0fjIWV//YeTaWrVnOxD89dPKfigCUspXFmjzOEUQpOkejH5Ly6sG0w==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
+      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.5.0",
-        "@lit/reactive-element": "^2.1.0",
-        "lit-html": "^3.3.0"
+        "@lit-labs/ssr-dom-shim": "^1.1.0",
+        "@lit/reactive-element": "^1.3.0",
+        "lit-html": "^2.8.0"
       }
     },
     "node_modules/lit-html": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.2.tgz",
-      "integrity": "sha512-Qy9hU88zcmaxBXcc10ZpdK7cOLXvXpRoBxERdtqV9QOrfpMZZ6pSYP91LhpPtap3sFMUiL7Tw2RImbe0Al2/kw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
+      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "homepage": "https://csansoon.github.io/ai-web-designer",
   "private": true,
   "dependencies": {
-    "@shoelace-style/shoelace": "^2.20.1",
+    "@shoelace-style/shoelace": "2.2.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import reportWebVitals from './reportWebVitals';
 
 import '@shoelace-style/shoelace/dist/themes/light.css';
 import { setBasePath } from '@shoelace-style/shoelace/dist/utilities/base-path';
-setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.20.1/cdn/');
+setBasePath('https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.2.0/dist/');
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(


### PR DESCRIPTION
## Summary
- pin Shoelace back to 2.2.0 and restore its matching CDN base path
- keep the modernization changes intact while removing the production-only lit-html crash path
- regenerate the lockfile for the working dependency set

## Why
The modernization PR upgraded Shoelace to 2.20.1, which pulled in Lit 3. In this Create React App production build, that dependency combination minifies into broken output and crashes on load with , leaving the app blank on GitHub Pages.

## Approach
I reproduced the failure against the deployed build, mapped the exception back to , and then verified that the last known-good Shoelace line avoids the broken minified output while preserving the rest of the modernization work.

## Test plan
- npm test
- npm run build
- headless Chromium against a locally served  production build

## Assumptions / tradeoffs
- This is a focused regression fix, so it prefers the smallest safe dependency rollback over a wider tooling migration away from Create React App.
- The repo still has upstream npm audit findings unrelated to this fix.
