### PR TITLE
fix responses payload growth and model list

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Live demo: https://csansoon.github.io/ai-web-designer/
 - Replaced the old single-shot JSON schema flow with a tool-driven OpenAI Responses API loop.
 - Introduced explicit code-editing tools: `setHtml`, `setCss`, and `setJs`.
 - Kept the app frontend-only while making the AI editing flow more agentic and iterative.
-- Preserved model selection, API key management, and usage tracking from the previous branch.
+- Preserved model selection, API key management, and usage tracking from the previous branch, while preferring explicit modern model IDs when a key exposes them.
 - Improved error handling for invalid keys, rate limits, networking failures, and context-length issues.
 - Added tests for the new orchestration helpers and multi-step tool loop.
 
@@ -42,7 +42,9 @@ npm run build
 
 ## API key model
 
-This app currently sends requests directly from the browser to OpenAI using a user-provided API key stored in local storage. For safety:
+This app currently sends requests directly from the browser to OpenAI using a user-provided API key stored in local storage. The model picker uses a curated preferred list of explicit model IDs (for example `gpt-5.4` and `gpt-5.3-codex`) but only shows entries that the current key can actually access via `/v1/models`, with a generic `gpt-5` fallback retained for compatibility.
+
+For safety:
 
 - prefer a project-scoped key
 - set a spend limit

--- a/src/App.js
+++ b/src/App.js
@@ -9,7 +9,7 @@ import Editor from './components/Editor';
 import Chat from './components/Chat';
 
 import ChatMessage from './components/ChatMessage';
-import AI, { MODELS, STORAGE_KEYS } from './model/AI';
+import AI, { STORAGE_KEYS } from './model/AI';
 
 const DEFAULT_HTML = `<main class="hero">
   <section>
@@ -66,12 +66,13 @@ function App() {
   const [loadingResponse, setLoadingResponse] = useState(false);
   const [usedTokens, setUsedTokens] = useState('0');
   const [moneySpent, setMoneySpent] = useState('0.0000');
+  const [availableModels, setAvailableModels] = useState(AI.availableModels);
   const [selectedModel, setSelectedModel] = useState(AI.getSelectedModel());
 
   const [isCheckingAPIKey, setIsCheckingAPIKey] = useState(false);
   const [showAPIKeyDialog, setShowAPIKeyDialog] = useState(!AI.isInitialized && !localStorage.getItem(STORAGE_KEYS.apiKey));
 
-  const modelDescription = useMemo(() => MODELS[selectedModel]?.description || '', [selectedModel]);
+  const modelDescription = useMemo(() => availableModels[selectedModel]?.description || '', [availableModels, selectedModel]);
 
   const checkAPIKeyValidity = useCallback(async (keyFromArgument) => {
     const key = keyFromArgument || localStorage.getItem(STORAGE_KEYS.apiKey);
@@ -86,9 +87,13 @@ function App() {
 
     if (isValid) {
       AI.initWithKey(key);
+      setAvailableModels(AI.availableModels);
+      setSelectedModel(AI.getSelectedModel());
       setShowAPIKeyDialog(false);
     } else {
       AI.clear();
+      setAvailableModels(AI.availableModels);
+      setSelectedModel(AI.getSelectedModel());
       localStorage.removeItem(STORAGE_KEYS.apiKey);
       setShowAPIKeyDialog(true);
     }
@@ -205,7 +210,7 @@ function App() {
         <div className="sidebar-panel">
           <div className="settings-panel">
             <SlSelect value={selectedModel} label="Model" onSlChange={handleModelChange} hoist>
-              {Object.entries(MODELS).map(([value, model]) => (
+              {Object.entries(availableModels).map(([value, model]) => (
                 <SlOption key={value} value={value}>{model.label}</SlOption>
               ))}
             </SlSelect>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -15,7 +15,7 @@ test('renders model selector and starter guidance', () => {
   render(<App />);
 
   expect(screen.getByText(/describe the page you want to build/i)).toBeInTheDocument();
-  expect(screen.getAllByText(/gpt-4.1-mini/i).length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/gpt-5-mini/i).length).toBeGreaterThan(0);
   expect(screen.getByText(/reset starter/i)).toBeInTheDocument();
 });
 

--- a/src/model/AI.js
+++ b/src/model/AI.js
@@ -6,7 +6,7 @@ const STORAGE_KEYS = {
   selectedModel: 'selected_model',
 };
 
-const MODELS = {
+const MODEL_METADATA = {
   'gpt-4.1-mini': {
     label: 'gpt-4.1-mini',
     inputCostPerMillion: 0.4,
@@ -19,8 +19,27 @@ const MODELS = {
     outputCostPerMillion: 8,
     description: 'Higher quality for larger or trickier page rewrites.',
   },
+  'gpt-4.1-nano': {
+    label: 'gpt-4.1-nano',
+    inputCostPerMillion: 0.1,
+    outputCostPerMillion: 0.4,
+    description: 'Lowest-cost 4.1 option for lightweight edits.',
+  },
+  'gpt-5-mini': {
+    label: 'gpt-5-mini',
+    inputCostPerMillion: 0.25,
+    outputCostPerMillion: 2,
+    description: 'Balanced GPT-5 model for faster drafting and iteration.',
+  },
+  'gpt-5': {
+    label: 'gpt-5',
+    inputCostPerMillion: 1.25,
+    outputCostPerMillion: 10,
+    description: 'Latest flagship GPT-5 model for higher-quality page generation.',
+  },
 };
 
+const DEFAULT_MODEL_ORDER = ['gpt-5-mini', 'gpt-5', 'gpt-4.1-mini', 'gpt-4.1', 'gpt-4.1-nano'];
 const MAX_TOOL_ROUNDS = 8;
 
 function buildSystemPrompt() {
@@ -144,9 +163,31 @@ function buildSummaryFallback(operations) {
   return `Applied updates with ${toolNames}.`;
 }
 
+function buildAvailableModelMap(modelIds = DEFAULT_MODEL_ORDER) {
+  return modelIds.reduce((accumulator, modelId) => {
+    const metadata = MODEL_METADATA[modelId];
+
+    if (metadata) {
+      accumulator[modelId] = metadata;
+    }
+
+    return accumulator;
+  }, {});
+}
+
+function normalizeModelListResponse(data) {
+  const ids = (data?.data || [])
+    .map((model) => model?.id)
+    .filter((id) => typeof id === 'string' && MODEL_METADATA[id]);
+
+  const orderedIds = DEFAULT_MODEL_ORDER.filter((id) => ids.includes(id));
+  return orderedIds.length > 0 ? orderedIds : DEFAULT_MODEL_ORDER;
+}
+
 class AI {
   static _apiKey = null;
   static _totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+  static _availableModelIds = [...DEFAULT_MODEL_ORDER];
 
   static initWithKey(key) {
     AI._apiKey = key;
@@ -156,6 +197,7 @@ class AI {
   static clear() {
     AI._apiKey = null;
     AI._totalUsage = { inputTokens: 0, outputTokens: 0, totalTokens: 0 };
+    AI._availableModelIds = [...DEFAULT_MODEL_ORDER];
   }
 
   static get isInitialized() {
@@ -163,19 +205,59 @@ class AI {
   }
 
   static get availableModels() {
-    return MODELS;
+    return buildAvailableModelMap(AI._availableModelIds);
   }
 
   static getSelectedModel() {
-    return localStorage.getItem(STORAGE_KEYS.selectedModel) || 'gpt-4.1-mini';
+    const storedModel = localStorage.getItem(STORAGE_KEYS.selectedModel);
+
+    if (storedModel && AI.availableModels[storedModel]) {
+      return storedModel;
+    }
+
+    return DEFAULT_MODEL_ORDER.find((modelId) => AI.availableModels[modelId]) || 'gpt-4.1-mini';
   }
 
   static setSelectedModel(model) {
-    if (!MODELS[model]) {
+    if (!AI.availableModels[model]) {
       throw new Error(`Unsupported model: ${model}`);
     }
 
     localStorage.setItem(STORAGE_KEYS.selectedModel, model);
+  }
+
+  static async refreshAvailableModels(key = AI._apiKey) {
+    if (!key) {
+      AI._availableModelIds = [...DEFAULT_MODEL_ORDER];
+      return AI.availableModels;
+    }
+
+    try {
+      const response = await fetch('https://api.openai.com/v1/models', {
+        headers: {
+          Authorization: `Bearer ${key}`,
+        },
+      });
+
+      if (!response.ok) {
+        AI._availableModelIds = [...DEFAULT_MODEL_ORDER];
+        return AI.availableModels;
+      }
+
+      const data = await response.json();
+      AI._availableModelIds = normalizeModelListResponse(data);
+
+      const selectedModel = localStorage.getItem(STORAGE_KEYS.selectedModel);
+      if (selectedModel && !AI.availableModels[selectedModel]) {
+        localStorage.setItem(STORAGE_KEYS.selectedModel, AI.getSelectedModel());
+      }
+
+      return AI.availableModels;
+    } catch (error) {
+      console.error(error);
+      AI._availableModelIds = [...DEFAULT_MODEL_ORDER];
+      return AI.availableModels;
+    }
   }
 
   static async checkAPIKey(key) {
@@ -186,7 +268,13 @@ class AI {
         },
       });
 
-      return response.ok;
+      if (!response.ok) {
+        return false;
+      }
+
+      const data = await response.json();
+      AI._availableModelIds = normalizeModelListResponse(data);
+      return true;
     } catch (error) {
       console.error(error);
       return false;
@@ -198,7 +286,7 @@ class AI {
   }
 
   static get totalUsedTokensUSD() {
-    const pricing = MODELS[AI.getSelectedModel()] || MODELS['gpt-4.1-mini'];
+    const pricing = AI.availableModels[AI.getSelectedModel()] || MODEL_METADATA['gpt-4.1-mini'];
     const inputCost = (AI._totalUsage.inputTokens / 1_000_000) * pricing.inputCostPerMillion;
     const outputCost = (AI._totalUsage.outputTokens / 1_000_000) * pricing.outputCostPerMillion;
     return inputCost + outputCost;
@@ -213,24 +301,31 @@ class AI {
     const startingArtifacts = getLatestArtifacts(messages);
     const nextArtifacts = { ...startingArtifacts };
     const operations = [];
-    const input = buildResponsesInput(messages);
+    let previousResponseId = null;
+    let nextInput = buildResponsesInput(messages);
 
     try {
       for (let round = 0; round < MAX_TOOL_ROUNDS; round += 1) {
+        const requestBody = {
+          model,
+          temperature: 0.3,
+          store: false,
+          instructions: buildSystemPrompt(),
+          tools: ARTIFACT_TOOL_DEFINITIONS,
+          input: nextInput,
+        };
+
+        if (previousResponseId) {
+          requestBody.previous_response_id = previousResponseId;
+        }
+
         const response = await fetch('https://api.openai.com/v1/responses', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${AI._apiKey}`,
           },
-          body: JSON.stringify({
-            model,
-            temperature: 0.3,
-            store: false,
-            instructions: buildSystemPrompt(),
-            tools: ARTIFACT_TOOL_DEFINITIONS,
-            input,
-          }),
+          body: JSON.stringify(requestBody),
         });
 
         const data = await response.json();
@@ -255,7 +350,7 @@ class AI {
         }
 
         updateUsage(data?.usage);
-        input.push(...(data?.output || []));
+        previousResponseId = data?.id || previousResponseId;
 
         const functionCalls = extractFunctionCalls(data);
 
@@ -272,15 +367,15 @@ class AI {
           );
         }
 
-        for (const functionCall of functionCalls) {
+        nextInput = functionCalls.map((functionCall) => {
           const result = applyArtifactToolCall(functionCall.name, functionCall.arguments, nextArtifacts);
 
           if (result.operation) {
             operations.push(result.operation);
           }
 
-          input.push(buildFunctionCallOutput(functionCall.call_id || functionCall.id, result.output));
-        }
+          return buildFunctionCallOutput(functionCall.call_id || functionCall.id, result.output);
+        });
       }
 
       return new ChatMessage('system', 'The AI editor exceeded the tool-call limit for this request. Try a smaller change.');
@@ -296,7 +391,8 @@ export {
   buildAssistantHistoryPayload,
   extractAssistantText,
   extractFunctionCalls,
-  MODELS,
+  normalizeModelListResponse,
+  MODEL_METADATA,
   STORAGE_KEYS,
 };
 export default AI;

--- a/src/model/AI.js
+++ b/src/model/AI.js
@@ -7,39 +7,53 @@ const STORAGE_KEYS = {
 };
 
 const MODEL_METADATA = {
-  'gpt-4.1-mini': {
-    label: 'gpt-4.1-mini',
-    inputCostPerMillion: 0.4,
-    outputCostPerMillion: 1.6,
-    description: 'Fast default for iterative web design edits.',
+  'gpt-5.4': {
+    label: 'gpt-5.4',
+    inputCostPerMillion: 1.25,
+    outputCostPerMillion: 10,
+    description: 'Preferred flagship model when the key has access to the latest GPT-5 tier.',
   },
-  'gpt-4.1': {
-    label: 'gpt-4.1',
-    inputCostPerMillion: 2,
-    outputCostPerMillion: 8,
-    description: 'Higher quality for larger or trickier page rewrites.',
-  },
-  'gpt-4.1-nano': {
-    label: 'gpt-4.1-nano',
-    inputCostPerMillion: 0.1,
-    outputCostPerMillion: 0.4,
-    description: 'Lowest-cost 4.1 option for lightweight edits.',
+  'gpt-5.3-codex': {
+    label: 'gpt-5.3-codex',
+    inputCostPerMillion: 1.25,
+    outputCostPerMillion: 10,
+    description: 'Code-leaning GPT-5 option for explicit HTML, CSS, and JavaScript edits.',
   },
   'gpt-5-mini': {
     label: 'gpt-5-mini',
     inputCostPerMillion: 0.25,
     outputCostPerMillion: 2,
-    description: 'Balanced GPT-5 model for faster drafting and iteration.',
+    description: 'Balanced lower-cost GPT-5 choice for faster drafting and iteration.',
   },
   'gpt-5': {
     label: 'gpt-5',
     inputCostPerMillion: 1.25,
     outputCostPerMillion: 10,
-    description: 'Latest flagship GPT-5 model for higher-quality page generation.',
+    description: 'Generic GPT-5 fallback kept for compatibility when a key exposes it explicitly.',
+  },
+  'gpt-4.1': {
+    label: 'gpt-4.1',
+    inputCostPerMillion: 2,
+    outputCostPerMillion: 8,
+    description: 'Reliable higher-quality fallback for larger or trickier page rewrites.',
+  },
+  'gpt-4.1-mini': {
+    label: 'gpt-4.1-mini',
+    inputCostPerMillion: 0.4,
+    outputCostPerMillion: 1.6,
+    description: 'Fast default fallback for iterative web design edits.',
+  },
+  'gpt-4.1-nano': {
+    label: 'gpt-4.1-nano',
+    inputCostPerMillion: 0.1,
+    outputCostPerMillion: 0.4,
+    description: 'Lowest-cost fallback for lightweight edits and experiments.',
   },
 };
 
-const DEFAULT_MODEL_ORDER = ['gpt-5-mini', 'gpt-5', 'gpt-4.1-mini', 'gpt-4.1', 'gpt-4.1-nano'];
+const PREFERRED_MODEL_ORDER = ['gpt-5.4', 'gpt-5.3-codex', 'gpt-5-mini', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano'];
+const COMPATIBILITY_MODEL_ORDER = ['gpt-5'];
+const DEFAULT_MODEL_ORDER = [...PREFERRED_MODEL_ORDER, ...COMPATIBILITY_MODEL_ORDER];
 const MAX_TOOL_ROUNDS = 8;
 
 function buildSystemPrompt() {
@@ -175,13 +189,24 @@ function buildAvailableModelMap(modelIds = DEFAULT_MODEL_ORDER) {
   }, {});
 }
 
-function normalizeModelListResponse(data) {
-  const ids = (data?.data || [])
+function getKnownModelIds(data) {
+  return (data?.data || [])
     .map((model) => model?.id)
     .filter((id) => typeof id === 'string' && MODEL_METADATA[id]);
+}
 
-  const orderedIds = DEFAULT_MODEL_ORDER.filter((id) => ids.includes(id));
-  return orderedIds.length > 0 ? orderedIds : DEFAULT_MODEL_ORDER;
+function normalizeModelListResponse(data) {
+  const knownModelIds = getKnownModelIds(data);
+
+  if (knownModelIds.length === 0) {
+    return [...DEFAULT_MODEL_ORDER];
+  }
+
+  const preferredIds = PREFERRED_MODEL_ORDER.filter((id) => knownModelIds.includes(id));
+  const compatibilityIds = COMPATIBILITY_MODEL_ORDER.filter((id) => knownModelIds.includes(id));
+  const additionalKnownIds = knownModelIds.filter((id) => !preferredIds.includes(id) && !compatibilityIds.includes(id));
+
+  return [...preferredIds, ...compatibilityIds, ...additionalKnownIds];
 }
 
 class AI {

--- a/src/model/AI.test.js
+++ b/src/model/AI.test.js
@@ -1,8 +1,10 @@
 import AI, {
+  MODEL_METADATA,
   buildAssistantHistoryPayload,
   buildResponsesInput,
   extractAssistantText,
   extractFunctionCalls,
+  normalizeModelListResponse,
 } from './AI';
 import ChatMessage from '../components/ChatMessage';
 import { applyArtifactToolCall } from './artifactTools';
@@ -99,6 +101,17 @@ describe('AI helpers', () => {
       reason: 'Swap in the updated layout',
     }));
   });
+
+  test('normalizeModelListResponse keeps supported modern models in preferred order', () => {
+    expect(normalizeModelListResponse({
+      data: [
+        { id: 'gpt-4.1' },
+        { id: 'gpt-5' },
+        { id: 'gpt-5-mini' },
+        { id: 'not-supported-here' },
+      ],
+    })).toEqual(['gpt-5-mini', 'gpt-5', 'gpt-4.1']);
+  });
 });
 
 describe('AI tool loop', () => {
@@ -116,6 +129,7 @@ describe('AI tool loop', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id: 'resp_1',
           usage: { input_tokens: 120, output_tokens: 30, total_tokens: 150 },
           output: [
             {
@@ -144,6 +158,7 @@ describe('AI tool loop', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
+          id: 'resp_2',
           usage: { input_tokens: 80, output_tokens: 20, total_tokens: 100 },
           output_text: 'Updated the hero markup and styling.',
           output: [
@@ -160,6 +175,25 @@ describe('AI tool loop', () => {
     ]);
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+    const firstRequest = JSON.parse(fetchSpy.mock.calls[0][1].body);
+    const secondRequest = JSON.parse(fetchSpy.mock.calls[1][1].body);
+
+    expect(firstRequest.previous_response_id).toBeUndefined();
+    expect(secondRequest.previous_response_id).toBe('resp_1');
+    expect(secondRequest.input).toEqual([
+      {
+        type: 'function_call_output',
+        call_id: 'call_1',
+        output: JSON.stringify({ ok: true, target: 'html', size: '<main><h1>New hero</h1></main>'.length }),
+      },
+      {
+        type: 'function_call_output',
+        call_id: 'call_2',
+        output: JSON.stringify({ ok: true, target: 'css', size: 'body { color: red; }'.length }),
+      },
+    ]);
+
     expect(responseMessage.role).toBe('assistant');
     expect(responseMessage.message).toBe('Updated the hero markup and styling.');
     expect(responseMessage.html).toBe('<main><h1>New hero</h1></main>');
@@ -167,5 +201,18 @@ describe('AI tool loop', () => {
     expect(responseMessage.js).toBeUndefined();
     expect(responseMessage.operations).toHaveLength(2);
     expect(AI.totalUsedTokens).toBe(250);
+  });
+
+  test('checkAPIKey updates available models from the API response', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: [{ id: 'gpt-5' }, { id: 'gpt-4.1' }],
+      }),
+    });
+
+    await expect(AI.checkAPIKey('test-key')).resolves.toBe(true);
+    expect(Object.keys(AI.availableModels)).toEqual(['gpt-5', 'gpt-4.1']);
+    expect(AI.availableModels['gpt-5']).toEqual(MODEL_METADATA['gpt-5']);
   });
 });

--- a/src/model/AI.test.js
+++ b/src/model/AI.test.js
@@ -102,15 +102,22 @@ describe('AI helpers', () => {
     }));
   });
 
-  test('normalizeModelListResponse keeps supported modern models in preferred order', () => {
+  test('normalizeModelListResponse keeps explicit preferred models first and compatibility fallbacks later', () => {
     expect(normalizeModelListResponse({
       data: [
-        { id: 'gpt-4.1' },
         { id: 'gpt-5' },
-        { id: 'gpt-5-mini' },
+        { id: 'gpt-4.1' },
+        { id: 'gpt-5.4' },
+        { id: 'gpt-5.3-codex' },
         { id: 'not-supported-here' },
       ],
-    })).toEqual(['gpt-5-mini', 'gpt-5', 'gpt-4.1']);
+    })).toEqual(['gpt-5.4', 'gpt-5.3-codex', 'gpt-4.1', 'gpt-5']);
+  });
+
+  test('normalizeModelListResponse falls back to the curated default order when no known models are returned', () => {
+    expect(normalizeModelListResponse({
+      data: [{ id: 'totally-unknown-model' }],
+    })).toEqual(['gpt-5.4', 'gpt-5.3-codex', 'gpt-5-mini', 'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano', 'gpt-5']);
   });
 });
 
@@ -203,16 +210,16 @@ describe('AI tool loop', () => {
     expect(AI.totalUsedTokens).toBe(250);
   });
 
-  test('checkAPIKey updates available models from the API response', async () => {
+  test('checkAPIKey updates available models from the API response using the explicit preference order', async () => {
     jest.spyOn(global, 'fetch').mockResolvedValue({
       ok: true,
       json: async () => ({
-        data: [{ id: 'gpt-5' }, { id: 'gpt-4.1' }],
+        data: [{ id: 'gpt-5' }, { id: 'gpt-5.3-codex' }, { id: 'gpt-4.1' }],
       }),
     });
 
     await expect(AI.checkAPIKey('test-key')).resolves.toBe(true);
-    expect(Object.keys(AI.availableModels)).toEqual(['gpt-5', 'gpt-4.1']);
-    expect(AI.availableModels['gpt-5']).toEqual(MODEL_METADATA['gpt-5']);
+    expect(Object.keys(AI.availableModels)).toEqual(['gpt-5.3-codex', 'gpt-4.1', 'gpt-5']);
+    expect(AI.availableModels['gpt-5.3-codex']).toEqual(MODEL_METADATA['gpt-5.3-codex']);
   });
 });


### PR DESCRIPTION
## Summary
- stop re-sending full tool-call payloads on every Responses API round and continue the loop with `previous_response_id` plus compact tool outputs
- load the model selector from the API-visible supported model set so GPT-5/GPT-5 mini and other modern entries appear when the key has access
- cover both regressions with focused tests around request chaining and model-list normalization

## Why
After the tool-loop work, large edits could exceed the context window because each loop iteration appended the model's prior `function_call` output — including full HTML/CSS/JS replacement arguments — back into the next request. The model selector regression came from a separate hardcoded two-model list, so newer models never appeared even when the API key could use them.

## Approach
I reproduced the request bloat by inspecting the second-round Responses payload in tests and fixed it by following the Responses API continuation pattern: keep the initial conversation in the first call, then send only `function_call_output` items alongside `previous_response_id` for later rounds. For models, I kept curated metadata/pricing locally but populate the visible selector from `/v1/models`, filtered to the supported modern models this app knows how to price and describe.

## Test plan
- npm test -- --watchAll=false
- npm run build

## Assumptions / tradeoffs
- The selector still shows only models this frontend has metadata for; unsupported `/v1/models` entries remain hidden rather than appearing with unknown pricing/UX copy.
- The production build still emits the existing third-party `qr-creator` source-map warning, but the build completes successfully.